### PR TITLE
feat: allow rule colors as strings

### DIFF
--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -34,8 +34,8 @@ def test_gradient_rule_rainbow_colors():
 
 
 def test_gradient_rule_color_validation():
-    with pytest.raises(ValueError):
-        Rule(title="BadColor", colors=["not-a-color"])
+    with pytest.raises(ColorParseError):
+        Rule(title="BadColor", colors=["#f00", "not-a-color"])
 
 
 def test_gradient_rule_invalid_thickness():


### PR DESCRIPTION
## Summary
- support parsing `Color` objects and RGB tuples in `Rule` so colors can be passed as strings like other components
- update tests to validate color parsing and expect `ColorParseError` for invalid colors

## Testing
- `PYENV_VERSION=3.13.3 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee94038148327922dcb60978b7d93

## Summary by Sourcery

Generalize Rule color handling to accept richer color inputs and improve error validation

New Features:
- Allow Rule colors to be passed as Color instances, ColorTriplet, or RGB tuples

Bug Fixes:
- Raise ColorParseError for invalid color values instead of ValueError
- Enforce at least two colors for a gradient by raising ValueError on insufficient inputs

Enhancements:
- Change colors parameter to accept a generic sequence of ColorType and refactor _parse_colors to handle multiple input types

Tests:
- Update tests to validate color parsing for new input types and expect ColorParseError on invalid colors