### PR TITLE
Enhance CLI feature set

### DIFF
--- a/src/rich_gradient/rule.py
+++ b/src/rich_gradient/rule.py
@@ -56,7 +56,9 @@ class Rule(Gradient):
     ) -> None:
         self.title = title or ""
         self.title_style = title_style
-        self.characters = CHARACTER_MAP.get(thickness, "━")
+        if thickness not in CHARACTER_MAP:
+            raise ValueError("thickness must be between 0 and 3 (inclusive)")
+        self.characters = thickness
 
         # Build the underlying Rich Rule renderable
         base_rule = RichRule(


### PR DESCRIPTION
## Summary
- rebuild the Typer CLI to expose rich-gradient text, syntax, markdown, JSON, and panel rendering options similar to rich-cli
- restore demo commands for gradients, panels, tables, progress, markup, prompts, live updates, and animations while supporting SVG export aliases
- harden helper utilities, including parse_renderable messaging and rule thickness validation

## Testing
- PYENV_VERSION=3.13.3 uv run ruff check
- PYENV_VERSION=3.13.3 uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ff89d097508327a39614c143954368

## Summary by Sourcery

Rebuild the Typer-based CLI to mirror rich-cli ergonomics, add advanced rendering modes and SVG export across commands, introduce animated gradient demos, and harden helper utilities.

New Features:
- Support JSON, Markdown, and syntax-highlighted inputs in the text command
- Add an --export-svg flag to save CLI output as SVG for all render commands
- Introduce animated demonstrations under animate gradient and animate panel subcommands
- Expose fine-grained panel styling options including box styles, padding, titles, captions, and expansion

Enhancements:
- Unify CLI flags and input sources (stdin, file paths, literals) and consolidate console configuration options (--width, --max-width, --force-terminal, --record)
- Add enums for justification, overflow, alignment, and box styles to strengthen option validation
- Refactor helper utilities (_read_text_source, _parse_padding, _create_console, _resolve_renderables) and improve parse_renderable error messaging

Chores:
- Validate GradientRule thickness range and raise errors for invalid values