### PR TITLE
Rewrite CLI to match documented commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,37 +1,125 @@
-# CLI
+# rich-gradient CLI
 
-`rich-gradient` ships with a Typer-based CLI that mirrors the capabilities of the library. It is ideal for quick experiments, demos during presentations, or exporting styled output to SVG.
+The `rich-gradient` package ships with a Typer-powered command line interface for
+rendering colourful gradients, animated gradients, and themed Rich components
+directly in your terminal. This document walks through installation, everyday
+usage, and all supported options.
 
-![CLI help](img/cli-help.svg)
+## Installation
 
-Run `rich-gradient --help` (or `uv run rich-gradient --help`) to see the full command list.
-
-## Core command: `text`
-
+```bash
+pip install rich-gradient rich-color-ext
 ```
-rich-gradient text "Hello, gradients!" -c "#38bdf8" -c "#a855f7" -c "#f97316"
+
+When working from a cloned repository you can also run the CLI in editable mode:
+
+```bash
+pip install -e .
+python -m rich_gradient.cli --help
 ```
 
-Common options:
+The CLI installs shell completions automatically via Typer:
 
-- `-c/--color`: repeatable foreground color stops.
-- `-b/--bgcolor`: background color stops.
-- `--rainbow`: generate a rainbow palette (ignored if colors are supplied).
-- `--justify`, `--overflow`, `--no-wrap`: forwarded to `Text`.
-- `--panel`, `--title`: wrap the output in a gradient-aware panel.
-- `--hues`: control the number of auto-generated color stops when colors aren’t supplied.
-- `--width`: render at a specific console width (useful before saving to SVG).
-- `--record`: enable the Rich `Console` recorder; combine with `--save-svg`.
-- `--save-svg PATH`: export the current render to an SVG, using the bundled gradient terminal theme.
+```bash
+rich-gradient --install-completion  # choose bash, zsh, or fish
+rich-gradient --show-completion zsh # preview the generated script
+```
 
-## Additional demos
+## Core Commands
 
-The CLI exposes shortcuts for many built-in renderables:
+Every command accepts text directly as an argument, via `text=...`, or by piping
+data into standard input using `-`. Invalid Rich markup is reported with a
+clear error message.
 
-- `gradient`: display a banner using the high-level [`Gradient`](gradient.md) class.
-- `panel`: render a gradient panel with gradient-accented title text.
-- `rule`: preview the gradient rule thicknesses.
-- `table`, `markdown`, `syntax`, `box`: show how gradients interact with common Rich components.
-- `progress`, `live`, `prompts`: animated demonstrations that leverage [`AnimatedGradient`](animation.md) internally.
+### `print`
 
-Each command accepts `--color`, `--bgcolor`, and `--rainbow` where it makes sense, so you can reuse palettes across different demos.
+Render gradient text or an animated gradient in place.
+
+Arguments:
+
+- `text`: Text to render, `-` for stdin, or `text=...`.
+
+Options:
+
+- `-c, --colors COLORS`: Comma-separated colour stops. (e.g. `#f00,#f90,#ff0`).
+- `-R/ -n, --rainbow/--no-rainbow`: Generate a rainbow gradient (default: off).
+- `-h, --hues INTEGER`: Number of hues when auto-generating colours (default: 7).
+- `-j, --justify [left|center|right]`: Align the output (default: left).
+- `-a, --animated`: Run an animated gradient instead of a static render.
+- `-d, --duration FLOAT`: Animation length in seconds (default: 5).
+
+Examples:
+
+```bash
+rich-gradient "Hello, World!" -c "#f00,#ff0,#0f0" -j center
+echo "streamed input" | rich-gradient print -
+rich-gradient print text="Animated from env" -R -a -d 8
+```
+
+### `rule`
+
+Draw a gradient or animated rule line, optionally with a title.
+
+Options:
+
+- `-t, --title TEXT`: Optional title shown in the rule.
+- `-s, --title-style TEXT`: Rich style for the title (default: bold).
+- `-j, --justify [left|center|right]`: Alignment for the title (default: center).
+- `-c, --colors TEXT`: Comma-separated colour stops.
+- `-R/ -n, --rainbow/--no-rainbow`: Toggle rainbow gradients.
+- `-h, --hues INTEGER`: Number of hues for generated colour ramps (default: 7).
+- `-T, --thickness INTEGER`: Line thickness between 0 and 3 (default: 1).
+- `-a, --animated`: Animate the rule with Rich Live.
+- `-d, --duration FLOAT`: Animation length in seconds (default: 5).
+
+Examples:
+
+```bash
+rich-gradient rule -t "Section 1" -c green,yellow -T 2
+rich-gradient rule -R -a -d 10
+rich-gradient rule --title "Status" --title-style "bold italic cyan"
+```
+
+### `panel`
+
+Produce a gradient panel around text or streamed content. Titles are aligned
+with the `--justify` option and padding is configurable.
+
+Arguments:
+
+- `text`: panel content, `-` for stdin, or `text=...`.
+
+Options:
+
+- `-t, --title TEXT`: Optional panel title.
+- `-s, --title-style TEXT`: Rich style for the panel title (default: bold).
+- `-j, --justify [left|center|right]`: Title alignment (default: center).
+- `-a, --align [left|center|right]`: Content alignment (default: left).
+- `-c, --colors TEXT`: Comma-separated color stops.
+- `-R/ -n, --rainbow/--no-rainbow`: Toggle rainbow gradients.
+- `-h, --hues INTEGER`: Number of hues for generated gradients (default: 7).
+- `-p, --padding TEXT`: Set padding as `N`, `V,H`, or `T,R,B,L`.
+- `--expand / --no-expand`: Control width expansion (default: expand).
+- `-a, --animated`: Animate the panel background.
+- `-d, --duration FLOAT`: Animation length in seconds (default: 5).
+
+Examples:
+
+```bash
+rich-gradient panel "Quick info" -t "Info" -c blue,cyan
+printf "Markdown? *Yes!*\n" | rich-gradient panel -t "Stream" -R
+rich-gradient panel -a -d 12 text="Animated background" -t "Live"
+```
+
+## Additional Features
+
+- `-V, --version` prints the installed `rich-gradient` version and exits.
+- All commands support `--help` for contextual usage.
+- `--rainbow/--no-rainbow` flags allow quick toggling without clearing other
+  options.
+- When `--animated` is supplied, the CLI uses the appropriate animated class
+  (`AnimatedGradient`, `AnimatedRule`, or `AnimatedPanel`) from the package.
+
+With these commands you can script colourful terminal output, build demos, or
+enhance dashboard tooling using the same gradient utilities available inside
+the library.

--- a/src/rich_gradient/cli.py
+++ b/src/rich_gradient/cli.py
@@ -1,1128 +1,453 @@
-"""Command line interface for ``rich-gradient``.
+"""Typer-based command line interface for ``rich-gradient``.
 
-This module exposes a Typer based command line application that mirrors the
-capabilities of the library. The CLI focuses on ergonomic defaults while also
-providing fine-grained control over gradient generation, alignment, panel
-styling, syntax highlighting, and animation playback. The options are inspired
-by the popular ``rich-cli`` utility so that existing Rich users feel right at
-home when using ``rich-gradient`` from the terminal.
+This module exposes three subcommands—``print``, ``rule``, and ``panel``—that
+mirror the usage documented in ``docs/cli.md``.  Each command accepts the same
+colour handling options (explicit stops, rainbow gradients, hue selection) and
+implements the ergonomic text sourcing described in the guide: inline text
+arguments, ``text=...`` syntax, or streamed standard input via ``-``.
+
+The CLI is intentionally compact so that the options showcased in the
+documentation remain the single source of truth for expected behaviour.  Helper
+functions centralise repeated tasks such as parsing colour stops, padding
+strings, and resolving text sources.
 """
 
 from __future__ import annotations
 
-import json
 import sys
-from io import StringIO
-from enum import Enum
+import time
 from pathlib import Path
-from time import sleep
-from typing import Iterable, List, Optional
+from typing import Literal, Optional, Sequence, Tuple
 
 import typer
-from rich import box
+from rich.align import Align
 from rich.color import ColorParseError
-from rich.console import Console, ConsoleRenderable, RichCast
-from rich.json import JSON as RichJSON
-from rich.markdown import Markdown
-from rich.markup import render as render_markup
-from rich.panel import Panel as RichPanel
-from rich.progress import (
-    BarColumn,
-    Progress,
-    TaskProgressColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
-from rich.prompt import Prompt
-from rich.syntax import Syntax
-from rich.table import Table
+from rich.console import Console, RenderableType
 from rich.text import Text as RichText
-from rich.live import Live
 
-from rich_gradient import Gradient, Rule as GradientRule, Text, __version__
+from rich_gradient import __version__
 from rich_gradient.animated_gradient import AnimatedGradient
 from rich_gradient.animated_panel import AnimatedPanel
-from rich_gradient.panel import Panel
-from rich_gradient.spectrum import Spectrum
-from rich_gradient.theme import GRADIENT_TERMINAL_THEME
+from rich_gradient.animated_rule import AnimatedRule
+from rich_gradient.panel import Panel as GradientPanel
+from rich_gradient.rule import Rule as GradientRule
+from rich_gradient.text import Text as GradientText
+
+JustifyOption = Literal["left", "center", "right"]
+
+app = typer.Typer(help="Render colourful text, rules, and panels using gradients.")
 
 
-class JustifyOption(str, Enum):
-    """Enumeration mapping CLI choices to ``JustifyMethod`` values."""
+def _create_console() -> Console:
+    """Return a console used for rendering CLI output."""
 
-    DEFAULT = "default"
-    LEFT = "left"
-    RIGHT = "right"
-    CENTER = "center"
-    FULL = "full"
+    return Console()
 
 
-class OverflowOption(str, Enum):
-    """Enumeration covering the overflow behaviours supported by ``Text``."""
+def _version_callback(value: bool) -> None:
+    """Print the installed package version when ``--version`` is supplied."""
 
-    FOLD = "fold"
-    CROP = "crop"
-    ELLIPSIS = "ellipsis"
-    IGNORE = "ignore"
-
-
-class AlignOption(str, Enum):
-    """Enumeration for horizontal alignment options used by several commands."""
-
-    LEFT = "left"
-    RIGHT = "right"
-    CENTER = "center"
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
 
 
-class VerticalAlignOption(str, Enum):
-    """Enumeration for vertical alignment choices used by gradient renderers."""
-
-    TOP = "top"
-    MIDDLE = "middle"
-    BOTTOM = "bottom"
-
-
-class BoxOption(str, Enum):
-    """Available Rich box styles exposed to the CLI."""
-
-    ROUNDED = "rounded"
-    HEAVY = "heavy"
-    DOUBLE = "double"
-    SQUARE = "square"
-    ASCII = "ascii"
-    ASCII2 = "ascii2"
-    SIMPLE = "simple"
-    SIMPLE_HEAD = "simple_head"
+@app.callback()
+def main(
+    version: bool = typer.Option(  # noqa: D401 - Typer uses the callback docstring.
+        False,
+        "--version",
+        "-V",
+        help="Show the rich-gradient version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    )
+) -> None:
+    """Root callback for shared global options."""
 
 
-BOX_STYLE_MAP: dict[BoxOption, box.Box] = {
-    BoxOption.ROUNDED: box.ROUNDED,
-    BoxOption.HEAVY: box.HEAVY,
-    BoxOption.DOUBLE: box.DOUBLE,
-    BoxOption.SQUARE: box.SQUARE,
-    BoxOption.ASCII: box.ASCII,
-    BoxOption.ASCII2: box.ASCII2,
-    BoxOption.SIMPLE: box.SIMPLE,
-    BoxOption.SIMPLE_HEAD: box.SIMPLE_HEAD,
-}
+def _read_text_source(argument: Optional[str]) -> str:
+    """Resolve command input from inline arguments, files, or standard input."""
 
-
-app = typer.Typer(help="Render gradients and export colourful output from the terminal.")
-
-
-def _read_text_source(source: Optional[str]) -> str:
-    """Read textual content from an argument, stdin, or a file path.
-
-    The behaviour mirrors ``rich-cli``:
-
-    * ``None`` – fall back to stdin when data is piped in, otherwise raise an
-      error so the user knows they need to supply content.
-    * ``-`` – always read from stdin, even if stdin is attached to a TTY.
-    * Existing path – load the file as UTF-8 encoded text.
-    * Everything else – treat the argument as the literal text to render.
-
-    Args:
-        source: Value provided by the CLI.  May be ``None`` when omitted.
-
-    Returns:
-        The textual content to render.
-
-    Raises:
-        typer.BadParameter: Raised when no data can be resolved.
-    """
-
-    if source == "-":
+    if argument is None:
+        if sys.stdin.isatty():
+            raise typer.BadParameter("provide text or pipe content to stdin")
         data = sys.stdin.read()
         if not data:
             raise typer.BadParameter("stdin did not provide any data")
         return data
 
-    if source is None:
-        if sys.stdin.isatty():
-            raise typer.BadParameter("provide text or pipe content to stdin")
-        return sys.stdin.read()
+    if argument == "-":
+        data = sys.stdin.read()
+        if not data:
+            raise typer.BadParameter("stdin did not provide any data")
+        return data
 
-    candidate_path = Path(source)
-    if candidate_path.exists() and candidate_path.is_file():
+    if argument.startswith("text="):
+        argument = argument.split("=", 1)[1]
+
+    candidate = Path(argument)
+    if candidate.exists() and candidate.is_file():
         try:
-            return candidate_path.read_text(encoding="utf-8")
+            return candidate.read_text(encoding="utf-8")
         except UnicodeDecodeError as error:  # pragma: no cover - defensive
             raise typer.BadParameter("file is not valid UTF-8 text") from error
 
-    return source
+    return argument
 
 
-def _parse_padding(value: Optional[str]) -> tuple[int, int, int, int]:
+def _parse_color_stops(spec: Optional[str]) -> Optional[Sequence[str]]:
+    """Split a comma-separated colour specification into individual stops."""
+
+    if spec is None:
+        return None
+    stops = [part.strip() for part in spec.split(",") if part.strip()]
+    if not stops:
+        raise typer.BadParameter("provide at least one colour stop")
+    return stops
+
+
+def _parse_padding(value: Optional[str]) -> Tuple[int, int, int, int]:
     """Parse padding strings (``"1"``, ``"2,4"``, ``"1,2,3,4"``) into a 4-tuple."""
 
-    if value is None:
+    if not value:
         return (0, 0, 0, 0)
     parts = [element.strip() for element in value.split(",") if element.strip()]
-    if not parts:
-        return (0, 0, 0, 0)
     try:
-        values = [int(part) for part in parts]
-    except ValueError as error:
+        numbers = [int(part) for part in parts]
+    except ValueError as error:  # pragma: no cover - validated via typer
         raise typer.BadParameter("padding must contain integers") from error
-    if len(values) == 1:
-        top = right = bottom = left = values[0]
-    elif len(values) == 2:
-        top, right = values
+
+    if len(numbers) == 1:
+        top = right = bottom = left = numbers[0]
+    elif len(numbers) == 2:
+        top, right = numbers
         bottom, left = top, right
-    elif len(values) == 4:
-        top, right, bottom, left = values
+    elif len(numbers) == 4:
+        top, right, bottom, left = numbers
     else:
         raise typer.BadParameter("padding requires 1, 2 or 4 integers")
     return (top, right, bottom, left)
 
 
-def _create_console(
-    width: Optional[int],
-    max_width: Optional[int],
-    record: bool,
-    force_terminal: bool,
-) -> Console:
-    """Create a ``Console`` configured from CLI flags."""
+def _as_list(values: Optional[Sequence[str]]) -> Optional[list[str]]:
+    """Convert an optional sequence of strings into a mutable list."""
 
-    kwargs: dict[str, object] = {"record": record, "force_terminal": force_terminal}
-    if width is not None:
-        kwargs["width"] = width
-    if max_width is not None:
-        kwargs["max_width"] = max_width
-    return Console(**kwargs)
+    return list(values) if values is not None else None
 
 
-def _save_svg(console: Console, destination: Optional[Path]) -> None:
-    """Persist the console buffer to an SVG file when requested."""
+def _run_animation(animation: AnimatedGradient, duration: float) -> None:
+    """Run an animated gradient for the requested duration."""
 
-    if destination is None:
+    if duration <= 0:
+        animation.start()
+        animation.stop()
         return
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    console.save_svg(
-        str(destination),
-        title="rich-gradient",
-        theme=GRADIENT_TERMINAL_THEME,
-        unique_id="rich-gradient-cli",
-    )
+
+    try:
+        with animation:
+            time.sleep(duration)
+    except KeyboardInterrupt:
+        animation.stop()
 
 
-def _resolve_renderables(lines: Iterable[str], markup: bool) -> list[ConsoleRenderable]:
-    """Convert a sequence of strings into Rich renderables."""
+def _handle_color_error(error: ColorParseError | ValueError) -> None:
+    """Convert colour parsing errors into user-facing CLI errors."""
 
-    renderables: list[ConsoleRenderable] = []
-    for line in lines:
-        if markup:
-            renderables.append(RichText.from_markup(line.rstrip("\n")))
-        else:
-            renderables.append(RichText(line.rstrip("\n")))
-    return renderables
+    raise typer.BadParameter(str(error)) from error
 
 
-def _maybe_warn_panel_title(panel_requested: bool, title: Optional[str]) -> None:
-    """Emit a friendly warning when panel specific options are ignored."""
-
-    if title and not panel_requested:
-        typer.echo("Warning: --title has no effect without --panel")
-
-
-def parse_renderable(value: str | RichCast | ConsoleRenderable) -> ConsoleRenderable:
-    """Coerce input into a Rich ``ConsoleRenderable`` instance.
-
-    Args:
-        value: A string, object implementing ``__rich__``, or an existing
-            ``ConsoleRenderable``.
-
-    Returns:
-        A ``ConsoleRenderable`` suitable for printing to a ``Console``.
-
-    Raises:
-        TypeError: Raised when the value cannot be converted into a renderable.
-    """
-
-    if isinstance(value, ConsoleRenderable):
-        return value
-    if isinstance(value, str):
-        return RichText.from_markup(value)
-    if hasattr(value, "__rich__"):
-        result = value.__rich__()
-        if isinstance(result, (str, ConsoleRenderable)) or hasattr(result, "__rich__"):
-            return parse_renderable(result)  # type: ignore[arg-type]
-        raise TypeError(
-            f"RichCast.__rich__() returned {type(result).__name__}, expected "
-            "str, RichCast, or ConsoleRenderable."
-        )
-    raise TypeError(
-        f"Cannot parse {type(value).__name__} to ConsoleRenderable. "
-        "Expected str, RichCast, or ConsoleRenderable."
-    )
-
-
-DEMO_COLORS: list[str] = ["#38bdf8", "#a855f7", "#f97316", "#fb7185"]
-
-
-def _demo_text(message: str, *, style: str = "", end: str = "\n") -> Text:
-    """Generate gradient text using the shared demo palette."""
-
-    return Text(message, colors=DEMO_COLORS, style=style, end=end)
-
-
-@app.command(name="text")
-def text_command(
-    source: Optional[str] = typer.Argument(
+@app.command("print")
+def print_command(  # noqa: D401 - Command help is provided via Typer metadata.
+    text: Optional[str] = typer.Argument(
         None,
-        help="Text, file path, or '-' to read from stdin.",
+        help="Text to render, '-' for stdin, or text=...",
     ),
-    color: List[str] = typer.Option(
-        [],
+    colors: Optional[str] = typer.Option(
+        None,
+        "--colors",
         "-c",
-        "--color",
-        help="Foreground gradient color stop. Repeat for multiple stops.",
+        help="Comma-separated colour stops (e.g. '#f00,#ff0,#0f0').",
     ),
-    bgcolor: List[str] = typer.Option(
-        [],
-        "-b",
-        "--bgcolor",
-        help="Background gradient color stop. Repeat for multiple stops.",
+    rainbow: bool = typer.Option(
+        False,
+        "--rainbow/--no-rainbow",
+        "-R/-n",
+        help="Generate a rainbow gradient automatically.",
     ),
-    rainbow: bool = typer.Option(False, "--rainbow", help="Generate a rainbow palette."),
-    hues: int = typer.Option(5, "--hues", min=2, help="Auto-generated hues when no stops provided."),
-    style: str = typer.Option("", "-s", "--style", help="Base style applied before gradients."),
+    hues: int = typer.Option(
+        7,
+        "--hues",
+        "-h",
+        min=2,
+        help="Number of hues when auto-generating colours.",
+    ),
     justify: JustifyOption = typer.Option(
-        JustifyOption.DEFAULT,
+        "left",
         "--justify",
-        help="Text justification passed to rich Text.",
+        "-j",
+        case_sensitive=False,
+        help="Align the rendered text.",
     ),
-    overflow: OverflowOption = typer.Option(
-        OverflowOption.FOLD,
-        "--overflow",
-        help="Overflow strategy (fold, crop, ellipsis, ignore).",
-    ),
-    no_wrap: bool = typer.Option(False, "--no-wrap", help="Disable word wrapping."),
-    end: str = typer.Option("\n", "--end", help="Trailing text appended after rendering."),
-    tab_size: int = typer.Option(4, "--tab-size", min=1, help="Tab size used by Rich Text."),
-    markup: bool = typer.Option(True, "--markup/--no-markup", help="Enable Rich markup parsing."),
-    markdown_mode: bool = typer.Option(
+    animated: bool = typer.Option(
         False,
-        "-m",
-        "--markdown",
-        help="Render the input as Markdown with gradient framing.",
+        "--animated",
+        "-a",
+        help="Animate the gradient instead of rendering once.",
     ),
-    json_mode: bool = typer.Option(
-        False,
-        "-J",
-        "--json",
-        help="Render the input as JSON with gradient framing.",
-    ),
-    syntax: bool = typer.Option(False, "--syntax", help="Syntax highlight the input."),
-    lexer: Optional[str] = typer.Option(
-        None,
-        "-x",
-        "--lexer",
-        help="Lexer to use with --syntax. Defaults to python when omitted.",
-    ),
-    theme: str = typer.Option(
-        "monokai",
-        "--theme",
-        help="Syntax highlighting theme when --syntax is used.",
-    ),
-    line_numbers: bool = typer.Option(
-        False,
-        "-n",
-        "--line-numbers",
-        help="Show line numbers for --syntax output.",
-    ),
-    guides: bool = typer.Option(
-        False,
-        "-g",
-        "--guides",
-        help="Show indentation guides for --syntax output.",
-    ),
-    syntax_no_wrap: bool = typer.Option(
-        False,
-        "--syntax-no-wrap",
-        help="Disable word wrapping for --syntax output.",
-    ),
-    head: Optional[int] = typer.Option(
-        None,
-        "--head",
-        min=1,
-        help="Only render the first N lines (requires --syntax).",
-    ),
-    tail: Optional[int] = typer.Option(
-        None,
-        "--tail",
-        min=1,
-        help="Only render the last N lines (requires --syntax).",
-    ),
-    width: Optional[int] = typer.Option(None, "-w", "--width", help="Explicit console width."),
-    max_width: Optional[int] = typer.Option(
-        None, "-W", "--max-width", help="Maximum console width for wrapping."
-    ),
-    panel: bool = typer.Option(False, "-a", "--panel", help="Wrap the output in a panel."),
-    panel_title: Optional[str] = typer.Option(None, "--title", help="Panel title when --panel is used."),
-    panel_caption: Optional[str] = typer.Option(
-        None, "--caption", help="Panel caption when --panel is used."
-    ),
-    panel_style: str = typer.Option("", "--panel-style", help="Style applied to the panel body."),
-    panel_box: BoxOption = typer.Option(
-        BoxOption.ROUNDED,
-        "--panel-box",
-        help="Panel border box style.",
-    ),
-    padding: Optional[str] = typer.Option(
-        None,
+    duration: float = typer.Option(
+        5.0,
+        "--duration",
         "-d",
-        "--padding",
-        help="Padding around panel content (1, 2 or 4 comma separated integers).",
-    ),
-    expand_panel: bool = typer.Option(
-        True, "--expand/--no-expand", help="Expand the panel to available width.", show_default=True
-    ),
-    record: bool = typer.Option(False, "--record", help="Enable console recording (required for SVG export)."),
-    save_svg: Optional[Path] = typer.Option(
-        None,
-        "--save-svg",
-        "--export-svg",
-        help="Write the render to an SVG file.",
-        show_default=False,
-    ),
-    force_terminal: bool = typer.Option(
-        False,
-        "--force-terminal",
-        help="Force terminal rendering even when stdout is redirected.",
+        min=0.0,
+        help="Animation length in seconds.",
     ),
 ) -> None:
-    """Render gradient text similar to ``rich-cli --print``."""
+    """Render gradient text or an animated gradient in place."""
 
-    if sum((markdown_mode, json_mode, syntax)) > 1:
-        raise typer.BadParameter("Choose at most one of --markdown, --json, or --syntax")
-    if (head is not None or tail is not None) and not syntax:
-        raise typer.BadParameter("--head/--tail require --syntax")
-    if head is not None and tail is not None:
-        raise typer.BadParameter("--head and --tail cannot be combined")
+    console = _create_console()
+    text_value = _read_text_source(text)
+    color_stops = _as_list(_parse_color_stops(colors))
 
-    content = _read_text_source(source)
     try:
-        renderable: ConsoleRenderable
-        if json_mode:
-            try:
-                data = json.loads(content)
-            except json.JSONDecodeError as error:  # pragma: no cover - user input validation
-                raise typer.BadParameter(f"invalid JSON: {error}") from error
-            renderable = Gradient(
-                RichJSON.from_data(data, indent=2),
-                colors=color or None,
-                bg_colors=bgcolor or None,
-                hues=hues,
+        if animated:
+            animation = AnimatedGradient(
+                renderables=text_value,
+                colors=color_stops,
                 rainbow=rainbow,
-                justify=justify.value,
-            )
-        elif markdown_mode:
-            renderable = Gradient(
-                Markdown(content),
-                colors=color or None,
-                bg_colors=bgcolor or None,
                 hues=hues,
-                rainbow=rainbow,
-                justify=justify.value,
+                console=console,
+                justify=justify,
+                expand=False,
             )
-        elif syntax:
-            snippet = content
-            lines = content.splitlines()
-            if head is not None:
-                snippet = "\n".join(lines[:head])
-            elif tail is not None:
-                snippet = "\n".join(lines[-tail:])
-            renderable = Gradient(
-                Syntax(
-                    snippet,
-                    lexer or "python",
-                    theme=theme,
-                    line_numbers=line_numbers,
-                    indent_guides=guides,
-                    word_wrap=not syntax_no_wrap,
-                ),
-                colors=color or None,
-                bg_colors=bgcolor or None,
-                hues=hues,
-                rainbow=rainbow,
-                justify=justify.value,
-            )
+            _run_animation(animation, duration)
         else:
-            renderable = Text(
-                text=content,
-                colors=color or None,
-                bgcolors=bgcolor or None,
+            gradient_text = GradientText(
+                text_value,
+                colors=color_stops,
                 rainbow=rainbow,
                 hues=hues,
-                style=style,
-                justify=justify.value,
-                overflow=overflow.value,
-                no_wrap=no_wrap,
-                end=end,
-                tab_size=tab_size,
-                markup=markup,
+                justify=justify,
             )
-    except (ColorParseError, ValueError, TypeError) as error:
-        typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(1) from error
-    _maybe_warn_panel_title(panel, panel_title)
-    console = _create_console(width, max_width, record or save_svg is not None, force_terminal)
-    if panel:
-        panel_renderable = RichPanel(
-            renderable,
-            title=panel_title,
-            subtitle=panel_caption,
-            expand=expand_panel,
-            box=BOX_STYLE_MAP[panel_box],
-            padding=_parse_padding(padding),
-            style=panel_style,
-        )
-        console.print(panel_renderable)
-    else:
-        console.print(renderable)
-    _save_svg(console, save_svg)
+            console.print(gradient_text)
+    except ColorParseError as error:
+        _handle_color_error(error)
 
 
-@app.command(name="gradient")
-def gradient_command(
-    line: Optional[List[str]] = typer.Argument(
+@app.command("rule")
+def rule_command(  # noqa: D401 - Command help is provided via Typer metadata.
+    title: Optional[str] = typer.Option(
         None,
-        help="Individual lines to include in the gradient. When omitted, read from stdin.",
+        "--title",
+        "-t",
+        help="Optional title displayed within the rule.",
     ),
-    color: List[str] = typer.Option(
-        [], "-c", "--color", help="Foreground color stops. Repeat for multiple values."
+    title_style: str = typer.Option(
+        "bold",
+        "--title-style",
+        "-s",
+        help="Rich style applied to the rule title.",
     ),
-    bgcolor: List[str] = typer.Option(
-        [], "-b", "--bgcolor", help="Background color stops. Repeat for multiple values."
-    ),
-    rainbow: bool = typer.Option(False, "--rainbow", help="Generate a rainbow gradient."),
-    hues: int = typer.Option(5, "--hues", min=2, help="Auto-generated hues when color stops missing."),
-    justify: AlignOption = typer.Option(
-        AlignOption.LEFT,
+    justify: JustifyOption = typer.Option(
+        "center",
         "--justify",
-        help="Horizontal alignment applied to the gradient output.",
+        "-j",
+        case_sensitive=False,
+        help="Alignment for the rule title.",
     ),
-    vertical_justify: VerticalAlignOption = typer.Option(
-        VerticalAlignOption.MIDDLE,
-        "--vertical",
-        help="Vertical alignment applied when expand is enabled.",
-    ),
-    markup: bool = typer.Option(True, "--markup/--no-markup", help="Treat input as Rich markup."),
-    expand: bool = typer.Option(True, "--expand/--no-expand", help="Expand to available width."),
-    record: bool = typer.Option(False, "--record", help="Record console output for export."),
-    width: Optional[int] = typer.Option(None, "-w", "--width", help="Explicit console width."),
-    max_width: Optional[int] = typer.Option(
-        None, "-W", "--max-width", help="Maximum width when wrapping output."
-    ),
-    force_terminal: bool = typer.Option(
-        False, "--force-terminal", help="Force terminal output when piping."
-    ),
-    save_svg: Optional[Path] = typer.Option(
+    colors: Optional[str] = typer.Option(
         None,
-        "--save-svg",
-        "--export-svg",
-        help="Write the gradient render to SVG.",
-        show_default=False,
+        "--colors",
+        "-c",
+        help="Comma-separated colour stops for the rule.",
+    ),
+    rainbow: bool = typer.Option(
+        False,
+        "--rainbow/--no-rainbow",
+        "-R/-n",
+        help="Generate a rainbow gradient across the rule.",
+    ),
+    hues: int = typer.Option(
+        7,
+        "--hues",
+        "-h",
+        min=2,
+        help="Number of hues when auto-generating colours.",
+    ),
+    thickness: int = typer.Option(
+        1,
+        "--thickness",
+        "-T",
+        min=0,
+        max=3,
+        help="Line thickness between 0 and 3.",
+    ),
+    animated: bool = typer.Option(
+        False,
+        "--animated",
+        "-a",
+        help="Animate the rule using Rich Live.",
+    ),
+    duration: float = typer.Option(
+        5.0,
+        "--duration",
+        "-d",
+        min=0.0,
+        help="Animation length in seconds.",
     ),
 ) -> None:
-    """Apply gradients across multiple renderables."""
+    """Draw a gradient rule line, optionally with animation."""
 
-    console = _create_console(width, max_width, record or save_svg is not None, force_terminal)
-    if not line:
-        stdin_payload = ""
-        if not sys.stdin.isatty():
-            stdin_payload = sys.stdin.read()
-            if stdin_payload:
-                line = stdin_payload.splitlines()
-        if not line:
-            banner = Gradient(
-                [
-                    _demo_text("Gradient Showcase", style="bold"),
-                    Text(
-                        "Smoothly blend colors across multiple renderables.",
-                        colors=list(reversed(DEMO_COLORS)),
-                        end="",
-                    ),
-                ],
-                colors=DEMO_COLORS,
+    console = _create_console()
+    color_stops = _as_list(_parse_color_stops(colors))
+
+    try:
+        if animated:
+            animation = AnimatedRule(
+                title=title,
+                title_style=title_style,
+                colors=color_stops,
+                rainbow=rainbow,
+                hues=hues,
+                thickness=thickness,
+                align=justify,
+                console=console,
+            )
+            _run_animation(animation, duration)
+        else:
+            rule_renderable = GradientRule(
+                title=title,
+                title_style=title_style,
+                colors=color_stops,
+                rainbow=rainbow,
+                hues=hues,
+                thickness=thickness,
+                align=justify,
+                console=console,
+            )
+            console.print(rule_renderable)
+    except (ColorParseError, ValueError) as error:
+        _handle_color_error(error)
+
+
+def _panel_content(text: str, align: JustifyOption) -> RenderableType:
+    """Return an aligned renderable for panel content."""
+
+    return Align(RichText.from_markup(text), align=align)
+
+
+@app.command("panel")
+def panel_command(  # noqa: D401 - Command help is provided via Typer metadata.
+    text: Optional[str] = typer.Argument(
+        None,
+        help="Panel content, '-' for stdin, or text=...",
+    ),
+    title: Optional[str] = typer.Option(
+        None,
+        "--title",
+        "-t",
+        help="Optional panel title.",
+    ),
+    title_style: str = typer.Option(
+        "bold",
+        "--title-style",
+        "-s",
+        help="Rich style applied to the panel title.",
+    ),
+    justify: JustifyOption = typer.Option(
+        "center",
+        "--justify",
+        "-j",
+        case_sensitive=False,
+        help="Title alignment inside the panel.",
+    ),
+    align: JustifyOption = typer.Option(
+        "left",
+        "--align",
+        case_sensitive=False,
+        help="Content alignment inside the panel.",
+    ),
+    colors: Optional[str] = typer.Option(
+        None,
+        "--colors",
+        "-c",
+        help="Comma-separated colour stops for the panel background.",
+    ),
+    rainbow: bool = typer.Option(
+        False,
+        "--rainbow/--no-rainbow",
+        "-R/-n",
+        help="Generate a rainbow panel background.",
+    ),
+    hues: int = typer.Option(
+        7,
+        "--hues",
+        "-h",
+        min=2,
+        help="Number of hues when auto-generating colours.",
+    ),
+    padding: Optional[str] = typer.Option(
+        None,
+        "--padding",
+        "-p",
+        help="Panel padding (N, V,H or T,R,B,L).",
+    ),
+    expand: bool = typer.Option(
+        True,
+        "--expand/--no-expand",
+        help="Expand the panel to available width.",
+    ),
+    animated: bool = typer.Option(
+        False,
+        "--animated",
+        "-a",
+        help="Animate the panel background.",
+    ),
+    duration: float = typer.Option(
+        5.0,
+        "--duration",
+        "-d",
+        min=0.0,
+        help="Animation length in seconds.",
+    ),
+) -> None:
+    """Produce a gradient-backed panel around text or streamed content."""
+
+    console = _create_console()
+    text_value = _read_text_source(text)
+    color_stops = _as_list(_parse_color_stops(colors))
+    padding_values = _parse_padding(padding)
+    content = _panel_content(text_value, align)
+
+    try:
+        if animated:
+            animation = AnimatedPanel(
+                content,
+                colors=color_stops,
+                rainbow=rainbow,
+                hues=hues,
+                title=title,
+                title_align=justify,
+                title_style=title_style,
+                padding=padding_values,
+                expand=expand,
+                console=console,
                 justify="center",
-                expand=True,
             )
-            console.print(banner)
-            typer.echo("Gradient Showcase")
-            _save_svg(console, save_svg)
-            return
-
-    renderables = _resolve_renderables(line, markup)
-    gradient = Gradient(
-        renderables,
-        colors=color or None,
-        bg_colors=bgcolor or None,
-        hues=hues,
-        rainbow=rainbow,
-        expand=expand,
-        justify=justify.value,
-        vertical_justify=vertical_justify.value,
-    )
-    console.print(gradient)
-    _save_svg(console, save_svg)
-
-
-@app.command(name="rule")
-def rule_command(
-    title: Optional[str] = typer.Argument(None, help="Optional title rendered inside the rule."),
-    color: List[str] = typer.Option(
-        [], "-c", "--color", help="Foreground color stops for the rule line."
-    ),
-    bgcolor: List[str] = typer.Option(
-        [], "-b", "--bgcolor", help="Background color stops for the rule line."
-    ),
-    rainbow: bool = typer.Option(False, "--rainbow", help="Use a rainbow palette regardless of color stops."),
-    hues: int = typer.Option(10, "--hues", min=2, help="Number of hues when auto-generating colors."),
-    thickness: int = typer.Option(2, "--thickness", min=0, max=3, help="Rule thickness (0-3)."),
-    title_style: str = typer.Option("bold", "--title-style", help="Style applied to the rule title."),
-    style: str = typer.Option("", "--style", help="Base style applied to the rule characters."),
-    align: AlignOption = typer.Option(
-        AlignOption.CENTER, "--align", help="Align the rule within the console width."
-    ),
-    end: str = typer.Option("\n", "--end", help="Characters appended after the rule."),
-    width: Optional[int] = typer.Option(None, "-w", "--width", help="Explicit console width."),
-    max_width: Optional[int] = typer.Option(
-        None, "-W", "--max-width", help="Maximum console width."
-    ),
-    force_terminal: bool = typer.Option(
-        False, "--force-terminal", help="Force terminal output when stdout is redirected."
-    ),
-    record: bool = typer.Option(False, "--record", help="Enable console recording."),
-    save_svg: Optional[Path] = typer.Option(
-        None,
-        "--save-svg",
-        "--export-svg",
-        help="Write the rendered rule to an SVG.",
-        show_default=False,
-    ),
-) -> None:
-    """Render a gradient powered rule."""
-
-    console = _create_console(width, max_width, record or save_svg is not None, force_terminal)
-    demo_mode = (
-        title is None
-        and not color
-        and not bgcolor
-        and not rainbow
-        and hues == 10
-        and thickness == 2
-        and style == ""
-        and title_style == "bold"
-        and align == AlignOption.CENTER
-        and end == "\n"
-    )
-    if demo_mode:
-        console.print(GradientRule("Gradient Rule", rainbow=True, thickness=1))
-        console.print(
-            _demo_text(
-                "Gradient rules are perfect for separating sections.",
-                style="italic",
+            _run_animation(animation, duration)
+        else:
+            panel_renderable = GradientPanel(
+                content,
+                colors=color_stops,
+                rainbow=rainbow,
+                hues=hues,
+                title=title,
+                title_align=justify,
+                title_style=title_style,
+                padding=padding_values,
+                expand=expand,
+                justify="center",
             )
-        )
-        _save_svg(console, save_svg)
-        return
-
-    rule = GradientRule(
-        title=title,
-        title_style=title_style,
-        colors=color or None,
-        bg_colors=bgcolor or None,
-        rainbow=rainbow,
-        hues=hues,
-        thickness=thickness,
-        style=style,
-        end=end,
-        align=align.value,
-    )
-    console.print(rule)
-    _save_svg(console, save_svg)
-
-
-@app.command(name="panel")
-def panel_command(
-    source: Optional[str] = typer.Argument(None, help="Content text, file path, or '-' for stdin."),
-    color: List[str] = typer.Option([], "-c", "--color", help="Foreground gradient stops."),
-    bgcolor: List[str] = typer.Option([], "-b", "--bgcolor", help="Background gradient stops."),
-    rainbow: bool = typer.Option(False, "--rainbow", help="Use a rainbow gradient."),
-    hues: int = typer.Option(5, "--hues", min=2, help="Auto-generated hues when no colors provided."),
-    title: Optional[str] = typer.Option(None, "--title", help="Panel title."),
-    title_align: AlignOption = typer.Option(
-        AlignOption.CENTER, "--title-align", help="Alignment for the panel title."
-    ),
-    title_style: str = typer.Option("bold", "--title-style", help="Style applied to the title."),
-    subtitle: Optional[str] = typer.Option(None, "--subtitle", help="Panel subtitle."),
-    subtitle_align: AlignOption = typer.Option(
-        AlignOption.RIGHT, "--subtitle-align", help="Alignment for the panel subtitle."
-    ),
-    subtitle_style: str = typer.Option("", "--subtitle-style", help="Style applied to the subtitle."),
-    border_style: str = typer.Option("", "--border-style", help="Border style for the panel."),
-    box_style: BoxOption = typer.Option(
-        BoxOption.ROUNDED, "--box", help="Border box type used for the panel."
-    ),
-    padding: Optional[str] = typer.Option(
-        None,
-        "-d",
-        "--padding",
-        help="Padding inside the panel (1, 2 or 4 comma separated integers).",
-    ),
-    justify: AlignOption = typer.Option(
-        AlignOption.LEFT, "--justify", help="Horizontal alignment for gradient application."
-    ),
-    vertical: VerticalAlignOption = typer.Option(
-        VerticalAlignOption.MIDDLE,
-        "--vertical",
-        help="Vertical alignment for gradient application.",
-    ),
-    expand: bool = typer.Option(True, "--expand/--no-expand", help="Expand panel to available width."),
-    style: str = typer.Option("", "--style", help="Style applied to the panel content."),
-    width: Optional[int] = typer.Option(None, "-w", "--width", help="Explicit console width."),
-    height: Optional[int] = typer.Option(None, "--height", help="Fixed panel height."),
-    safe_box: bool = typer.Option(False, "--safe-box", help="Use ASCII safe box drawing characters."),
-    markup: bool = typer.Option(True, "--markup/--no-markup", help="Interpret content as Rich markup."),
-    record: bool = typer.Option(False, "--record", help="Enable console recording."),
-    save_svg: Optional[Path] = typer.Option(
-        None,
-        "--save-svg",
-        "--export-svg",
-        help="Write the rendered panel to SVG.",
-        show_default=False,
-    ),
-    force_terminal: bool = typer.Option(
-        False, "--force-terminal", help="Force terminal rendering when stdout is redirected."
-    ),
-) -> None:
-    """Render a gradient panel with fine grained styling controls."""
-
-    console = _create_console(width, None, record or save_svg is not None, force_terminal)
-    if source is None:
-        payload = ""
-        if not sys.stdin.isatty():
-            payload = sys.stdin.read()
-        if sys.stdin.isatty() or not payload:
-            demo_panel = RichPanel(
-                _demo_text("Panels can frame gradient text for call-outs and highlights."),
-                title=_demo_text("Gradient Panel", style="bold", end=""),
-                border_style=DEMO_COLORS[0],
-                box=box.ROUNDED,
-            )
-            console.print(demo_panel)
-            typer.echo("Panels can frame gradient text for call-outs and highlights.")
-            _save_svg(console, save_svg)
-            return
-        content = payload
-    else:
-        content = _read_text_source(source)
-    inner = Text(
-        content,
-        colors=color or None,
-        bgcolors=bgcolor or None,
-        rainbow=rainbow,
-        hues=hues,
-        markup=markup,
-    )
-    panel = Panel(
-        inner,
-        colors=color or None,
-        bg_colors=bgcolor or None,
-        rainbow=rainbow,
-        hues=hues,
-        title=title,
-        title_align=title_align.value,
-        title_style=title_style,
-        subtitle=subtitle,
-        subtitle_align=subtitle_align.value,
-        subtitle_style=subtitle_style,
-        border_style=border_style,
-        box=BOX_STYLE_MAP[box_style],
-        padding=_parse_padding(padding),
-        expand=expand,
-        style=style,
-        width=width,
-        height=height,
-        safe_box=safe_box,
-        justify=justify.value,
-        vertical_justify=vertical.value,
-    )
-    console.print(panel)
-    _save_svg(console, save_svg)
-
-
-@app.command(name="spectrum")
-def spectrum_command(
-    hues: int = typer.Option(17, "--hues", min=2, help="Number of colors to display."),
-    invert: bool = typer.Option(False, "--invert", help="Reverse the generated palette."),
-    seed: Optional[int] = typer.Option(None, "--seed", help="Seed for deterministic ordering."),
-    width: Optional[int] = typer.Option(None, "-w", "--width", help="Console width."),
-    max_width: Optional[int] = typer.Option(
-        None, "-W", "--max-width", help="Maximum console width."
-    ),
-    record: bool = typer.Option(False, "--record", help="Enable console recording."),
-    save_svg: Optional[Path] = typer.Option(
-        None,
-        "--save-svg",
-        "--export-svg",
-        help="Write the spectrum table to SVG.",
-        show_default=False,
-    ),
-    force_terminal: bool = typer.Option(False, "--force-terminal", help="Force terminal rendering."),
-) -> None:
-    """Display the built-in color spectrum."""
-
-    spectrum = Spectrum(hues=hues, invert=invert, seed=seed)
-    console = _create_console(width, max_width, record or save_svg is not None, force_terminal)
-    console.print(spectrum)
-    _save_svg(console, save_svg)
-
-
-@app.command(name="table")
-def table_command() -> None:
-    """Render a gradient-enhanced table demo."""
-
-    console = Console()
-    table = Table(
-        title=_demo_text("Gradient Table", style="bold", end=""),
-        box=box.SIMPLE_HEAD,
-        expand=True,
-    )
-    table.add_column(_demo_text("Feature", style="bold", end=""))
-    table.add_column(_demo_text("Description", style="bold", end=""))
-    table.add_row(
-        _demo_text("Color stops", end=""),
-        Text(
-            "Blend multiple colors across content.",
-            colors=list(reversed(DEMO_COLORS)),
-            end="",
-        ),
-    )
-    table.add_row(
-        _demo_text("Backgrounds", end=""),
-        _demo_text("Add gradient backgrounds for extra depth.", end=""),
-    )
-    console.print(table)
-
-
-@app.command(name="progress")
-def progress_command() -> None:
-    """Run a short gradient accented progress demo."""
-
-    console = Console()
-    console.print(_demo_text("Starting gradient progress demo…"))
-    with Progress(
-        TextColumn("{task.description}", justify="left"),
-        BarColumn(bar_width=None),
-        TaskProgressColumn(),
-        TimeElapsedColumn(),
-        console=console,
-        transient=True,
-    ) as progress:
-        task_id = progress.add_task("Applying colors", total=3)
-        for step in range(3):
-            progress.update(task_id, description=f"Applying colors step {step + 1}")
-            sleep(0.05)
-            progress.advance(task_id)
-    console.print(_demo_text("Gradient progress complete!"))
-
-
-@app.command(name="syntax")
-def syntax_command() -> None:
-    """Render a syntax-highlighted snippet with gradient framing."""
-
-    console = Console()
-    code_sample = """def blend(colors):\n    return ' → '.join(colors)"""
-    syntax = Syntax(code_sample, "python", line_numbers=True, word_wrap=True)
-    console.print(
-        Gradient(
-            [
-                _demo_text("Gradient Syntax", style="bold"),
-                syntax,
-            ],
-            colors=DEMO_COLORS,
-            expand=True,
-        )
-    )
-
-
-@app.command(name="markdown")
-def markdown_command() -> None:
-    """Render Markdown content with gradient styling."""
-
-    console = Console()
-    markdown = Markdown(
-        """# Gradient Markdown\n\n- Smooth transitions\n- Vibrant palettes\n- Easy CLI demos"""
-    )
-    console.print(
-        Gradient(
-            [markdown],
-            colors=list(reversed(DEMO_COLORS)),
-            expand=True,
-        )
-    )
-
-
-@app.command(name="markup")
-def markup_command() -> None:
-    """Demonstrate Rich markup parsed into gradient text."""
-
-    console = Console()
-    parsed = render_markup("[bold]Rich[/bold] [italic]markup[/italic] meets gradients!")
-    gradient_text = Text(
-        parsed.plain,
-        colors=DEMO_COLORS,
-        spans=list(parsed.spans),
-        markup=False,
-    )
-    console.print(gradient_text)
-
-
-@app.command(name="box")
-def box_command() -> None:
-    """Preview several box styles with gradient text."""
-
-    console = Console()
-    samples = [
-        ("ROUNDED", box.ROUNDED),
-        ("HEAVY", box.HEAVY),
-        ("DOUBLE", box.DOUBLE),
-    ]
-    for label, box_type in samples:
-        console.print(
-            RichPanel(
-                _demo_text(f"{label.title()} borders pair nicely with gradients."),
-                title=_demo_text(label, style="bold", end=""),
-                border_style=DEMO_COLORS[1],
-                box=box_type,
-            )
-        )
-
-
-@app.command(name="prompts")
-def prompts_command() -> None:
-    """Simulate prompt interaction using gradient-styled questions."""
-
-    console = Console()
-    prompt_text = _demo_text("What's your favorite gradient palette? ", end="")
-    fake_input = StringIO("Aurora Borealis\n")
-    response = Prompt.ask(
-        prompt_text,
-        console=console,
-        stream=fake_input,
-        default="Aurora Borealis",
-        show_default=True,
-    )
-    console.print(_demo_text(f"Simulated response: {response}"))
-
-
-@app.command(name="live")
-def live_command() -> None:
-    """Stream live updates with gradient styling."""
-
-    console = Console()
-    messages = [
-        _demo_text("Preparing live gradient demo…", end=""),
-        _demo_text("Streaming colorful updates…", end=""),
-        _demo_text("Live rendering complete!", end=""),
-    ]
-    with Live(
-        RichPanel(messages[0], border_style=DEMO_COLORS[0], box=box.ROUNDED),
-        console=console,
-        refresh_per_second=6,
-    ) as live:
-        for message in messages[1:]:
-            sleep(0.05)
-            live.update(RichPanel(message, border_style=DEMO_COLORS[2], box=box.ROUNDED))
-    console.print(_demo_text("Exited live rendering session."))
-
-
-animate_app = typer.Typer(help="Animated gradient demonstrations.")
-
-
-@animate_app.command(name="gradient")
-def animated_gradient_command(
-    source: Optional[List[str]] = typer.Argument(
-        None,
-        help="Textual content for the animated gradient. Reads stdin when omitted.",
-    ),
-    color: List[str] = typer.Option([], "-c", "--color", help="Foreground gradient stops."),
-    bgcolor: List[str] = typer.Option([], "-b", "--bgcolor", help="Background gradient stops."),
-    rainbow: bool = typer.Option(False, "--rainbow", help="Animate using a rainbow gradient."),
-    hues: int = typer.Option(5, "--hues", min=2, help="Auto-generated color stops when none provided."),
-    expand: bool = typer.Option(False, "--expand/--no-expand", help="Expand renderables to fill the terminal."),
-    justify: AlignOption = typer.Option(
-        AlignOption.LEFT, "--justify", help="Horizontal alignment for the animation."
-    ),
-    vertical: VerticalAlignOption = typer.Option(
-        VerticalAlignOption.TOP,
-        "--vertical",
-        help="Vertical alignment for the animation.",
-    ),
-    refresh_per_second: float = typer.Option(
-        30.0, "--refresh", min=1.0, help="Refresh rate for the animation."
-    ),
-    phase_per_second: Optional[float] = typer.Option(
-        None,
-        "--phase",
-        help="Phase advance per second (cycles/s). Defaults to 0.12 for 30 FPS.",
-    ),
-    duration: Optional[float] = typer.Option(
-        None,
-        "--duration",
-        help="Automatically stop the animation after the given number of seconds.",
-    ),
-) -> None:
-    """Play an animated gradient using ``AnimatedGradient``."""
-
-    if not source:
-        if sys.stdin.isatty():
-            raise typer.BadParameter("provide content or pipe data for the animation")
-        source = sys.stdin.read().splitlines()
-
-    renderables = _resolve_renderables(source, markup=True)
-    animation = AnimatedGradient(
-        renderables=renderables,
-        colors=color or None,
-        bg_colors=bgcolor or None,
-        rainbow=rainbow,
-        hues=hues,
-        expand=expand,
-        justify=justify.value,
-        vertical_justify=vertical.value,
-        refresh_per_second=refresh_per_second,
-        phase_per_second=phase_per_second,
-    )
-    if duration is None:
-        typer.echo("Press CTRL+C to stop the animation.")
-        try:
-            animation.run()
-        except KeyboardInterrupt:
-            pass
-        return
-    animation.start()
-    try:
-        sleep(duration)
-    except KeyboardInterrupt:
-        pass
-    finally:
-        animation.stop()
-
-
-@animate_app.command(name="panel")
-def animated_panel_command(
-    source: Optional[str] = typer.Argument(
-        None,
-        help="Content text, file path, or '-' for stdin to animate within a panel.",
-    ),
-    color: List[str] = typer.Option([], "-c", "--color", help="Foreground gradient stops."),
-    bgcolor: List[str] = typer.Option([], "-b", "--bgcolor", help="Background gradient stops."),
-    rainbow: bool = typer.Option(False, "--rainbow", help="Use rainbow gradients."),
-    hues: int = typer.Option(5, "--hues", min=2, help="Auto-generated hues when colors missing."),
-    title: Optional[str] = typer.Option(None, "--title", help="Panel title."),
-    subtitle: Optional[str] = typer.Option(None, "--subtitle", help="Panel subtitle."),
-    border_style: str = typer.Option("", "--border-style", help="Panel border style."),
-    box_style: BoxOption = typer.Option(
-        BoxOption.ROUNDED, "--box", help="Box style used by the panel border."
-    ),
-    padding: Optional[str] = typer.Option(
-        None,
-        "-d",
-        "--padding",
-        help="Padding inside the panel (1, 2 or 4 comma separated integers).",
-    ),
-    expand: bool = typer.Option(True, "--expand/--no-expand", help="Expand panel to available width."),
-    refresh_per_second: float = typer.Option(
-        30.0, "--refresh", min=1.0, help="Refresh rate for the animation."
-    ),
-    phase_per_second: Optional[float] = typer.Option(
-        None,
-        "--phase",
-        help="Phase advance per second (cycles/s). Defaults to 0.12 at 30 FPS.",
-    ),
-    duration: Optional[float] = typer.Option(
-        None,
-        "--duration",
-        help="Automatically stop the animation after the given number of seconds.",
-    ),
-) -> None:
-    """Animate a gradient panel."""
-
-    content = _read_text_source(source)
-    inner = RichText.from_markup(content)
-    panel = Panel(
-        inner,
-        colors=color or None,
-        bg_colors=bgcolor or None,
-        rainbow=rainbow,
-        hues=hues,
-        title=title,
-        subtitle=subtitle,
-        border_style=border_style,
-        box=BOX_STYLE_MAP[box_style],
-        padding=_parse_padding(padding),
-        expand=expand,
-    )
-    animation = AnimatedPanel(
-        panel,
-        colors=color or None,
-        bg_colors=bgcolor or None,
-        rainbow=rainbow,
-        hues=hues,
-        refresh_per_second=refresh_per_second,
-        phase_per_second=phase_per_second,
-    )
-    if duration is None:
-        typer.echo("Press CTRL+C to stop the animation.")
-        try:
-            animation.run()
-        except KeyboardInterrupt:
-            pass
-        return
-    animation.start()
-    try:
-        sleep(duration)
-    except KeyboardInterrupt:
-        pass
-    finally:
-        animation.stop()
-
-
-app.add_typer(animate_app, name="animate")
-
-
-@app.callback()
-def main_callback(
-    version: Optional[bool] = typer.Option(
-        None,
-        "-v",
-        "--version",
-        help="Print the rich-gradient version and exit.",
-        callback=lambda value: _show_version(value),
-        is_eager=True,
-    )
-) -> None:
-    """Entry point for Typer application."""
-
-    del version  # ``version`` is handled by the eager callback
-
-
-def _show_version(value: Optional[bool]) -> None:
-    """Display the package version when the --version flag is used."""
-
-    if value:
-        typer.echo(f"rich-gradient {__version__}")
-        raise typer.Exit()
-
-
-def run() -> None:
-    """Execute the Typer application."""
-
-    app()
-
-
-if __name__ == "__main__":
-    run()
+            console.print(panel_renderable)
+    except ColorParseError as error:
+        _handle_color_error(error)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,278 +1,127 @@
+"""Integration tests for the Typer-based ``rich-gradient`` CLI."""
+
+from __future__ import annotations
+
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
-from rich.text import Text as RichText
-from rich.panel import Panel
-from rich.console import ConsoleRenderable
 
-from rich_gradient.cli import app, parse_renderable
-
+from rich_gradient.cli import app
 
 runner = CliRunner()
 
 
-def test_parse_renderable_string():
-    """Test that parse_renderable converts strings to RichText."""
-    result = parse_renderable("Hello World")
-    assert isinstance(result, ConsoleRenderable)
-    assert isinstance(result, RichText)
-    assert result.plain == "Hello World"
+def test_version_option() -> None:
+    """``--version`` should print the installed package version."""
 
-
-def test_parse_renderable_with_markup():
-    """Test that parse_renderable handles Rich markup in strings."""
-    result = parse_renderable("[bold]Hello[/bold]")
-    assert isinstance(result, RichText)
-    assert result.plain == "Hello"
-    # Markup should create spans
-    assert len(result._spans) > 0
-
-
-def test_parse_renderable_console_renderable():
-    """Test that parse_renderable passes through ConsoleRenderable objects."""
-    panel = Panel("Test")
-    result = parse_renderable(panel)
-    assert result is panel  # Should be the same object
-
-
-def test_parse_renderable_rich_cast():
-    """Test that parse_renderable handles RichCast objects."""
-    
-    class MyRichCast:
-        def __rich__(self):
-            return RichText("From RichCast")
-    
-    obj = MyRichCast()
-    result = parse_renderable(obj)
-    assert isinstance(result, ConsoleRenderable)
-    assert isinstance(result, RichText)
-    assert result.plain == "From RichCast"
-
-
-def test_parse_renderable_rich_cast_string():
-    """Test that parse_renderable handles RichCast objects that return strings."""
-    
-    class MyRichCast:
-        def __rich__(self):
-            return "String from RichCast"
-    
-    obj = MyRichCast()
-    result = parse_renderable(obj)
-    assert isinstance(result, RichText)
-    assert result.plain == "String from RichCast"
-
-
-def test_parse_renderable_nested_rich_cast():
-    """Test that parse_renderable handles nested RichCast objects."""
-    
-    class InnerRichCast:
-        def __rich__(self):
-            return RichText("Nested")
-    
-    class OuterRichCast:
-        def __rich__(self):
-            return InnerRichCast()
-    
-    obj = OuterRichCast()
-    result = parse_renderable(obj)
-    assert isinstance(result, ConsoleRenderable)
-    assert isinstance(result, RichText)
-    assert result.plain == "Nested"
-
-
-def test_parse_renderable_invalid_type():
-    """Test that parse_renderable raises TypeError for invalid types."""
-    try:
-        parse_renderable(123)  # type: ignore
-        assert False, "Should have raised TypeError"
-    except TypeError as e:
-        assert "Cannot parse" in str(e)
-
-
-def test_parse_renderable_invalid_rich_cast():
-    """Test that parse_renderable raises TypeError for RichCast returning invalid types."""
-    
-    class BadRichCast:
-        def __rich__(self):
-            return 123  # Invalid return type
-    
-    obj = BadRichCast()
-    try:
-        parse_renderable(obj)
-        assert False, "Should have raised TypeError"
-    except TypeError as e:
-        assert "returned" in str(e)
-
-
-def test_cli_text_basic():
-    result = runner.invoke(app, ["text", "Hello", "-c", "magenta", "-c", "cyan"])
+    result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    # Ensure plain text made it to output
-    assert "Hello" in result.stdout
+    assert result.stdout.strip()  # Version string is non-empty
 
 
-def test_cli_save_svg(tmp_path: Path):
-    svg_path = tmp_path / "out.svg"
-    result = runner.invoke(app, [
-        "text",
-        "Hello SVG",
-        "--save-svg",
-        str(svg_path),
-        "--width",
-        "60",
-    ])
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (["print", "Hello world"], "Hello world"),
+        (["print", "text=From assignment"], "From assignment"),
+    ],
+)
+def test_print_command_renders_text(args: list[str], expected: str) -> None:
+    """The ``print`` command should render supplied text immediately."""
+
+    result = runner.invoke(app, args)
     assert result.exit_code == 0
-    assert svg_path.exists()
-    # Quick sanity check that it's an SVG file
-    content = svg_path.read_text(encoding="utf-8", errors="ignore")
-    assert "<svg" in content
+    assert expected in result.stdout
 
 
-def test_cli_title_without_panel_warns():
-    # Omit mix_stderr for broader Click/Typer compatibility
-    result = runner.invoke(app, ["text", "Warn", "--title", "T"]) 
+def test_print_command_reads_stdin() -> None:
+    """Passing ``-`` should read text from standard input."""
+
+    result = runner.invoke(app, ["print", "-"], input="Streamed input")
     assert result.exit_code == 0
-    warning = "Warning: --title has no effect without --panel"
-    # Accept either stdout or stderr depending on environment
-    assert (warning in result.stdout) or (warning in result.stderr)
+    assert "Streamed input" in result.stdout
 
 
-def test_cli_invalid_color_exits_with_error():
-    result = runner.invoke(app, ["text", "Bad", "-c", "#GGGGGG"])
+def test_print_command_handles_colours() -> None:
+    """Explicit colour stops should render without errors."""
+
+    result = runner.invoke(app, ["print", "Colourful", "-c", "#f00,#0f0"])
+    assert result.exit_code == 0
+    assert "Colourful" in result.stdout
+
+
+def test_print_command_rejects_invalid_colour() -> None:
+    """An invalid colour stop should produce an error message."""
+
+    result = runner.invoke(app, ["print", "Bad", "-c", "not-a-colour"])
     assert result.exit_code != 0
-    assert "Error:" in result.stdout or "Error:" in result.stderr
+    assert "Error" in result.stdout
 
 
-def test_parse_renderable_with_string():
-    """Test parse_renderable with string input."""
-    result = parse_renderable("Hello, [bold]World[/bold]!")
-    assert isinstance(result, RichText)
-    assert result.plain == "Hello, World!"
+def test_print_command_supports_animation() -> None:
+    """Animations with zero duration should complete immediately."""
 
-
-def test_parse_renderable_with_console_renderable():
-    """Test parse_renderable with ConsoleRenderable (Panel) input."""
-    panel = Panel("Test content", title="Test")
-    result = parse_renderable(panel)
-    assert result is panel  # Should return the same object
-    assert isinstance(result, Panel)
-
-
-def test_parse_renderable_with_richcast():
-    """Test parse_renderable with RichCast (object with __rich__ method)."""
-    class CustomRenderable:
-        def __rich__(self):
-            return RichText("Custom content")
-    
-    custom = CustomRenderable()
-    result = parse_renderable(custom)
-    assert isinstance(result, RichText)
-    assert result.plain == "Custom content"
-
-
-def test_parse_renderable_with_richcast_returning_string():
-    """Test parse_renderable with RichCast that returns a string."""
-    class StringRichCast:
-        def __rich__(self):
-            return "[green]Green text[/green]"
-    
-    string_cast = StringRichCast()
-    result = parse_renderable(string_cast)
-    assert isinstance(result, RichText)
-    assert result.plain == "Green text"
-
-
-def test_parse_renderable_with_richtext():
-    """Test parse_renderable with RichText input."""
-    text = RichText("Direct text", style="bold")
-    result = parse_renderable(text)
-    assert result is text  # Should return the same object
-    assert isinstance(result, RichText)
-
-
-def test_cli_gradient_command():
-    """Gradient command should render gradient showcase text."""
-
-    result = runner.invoke(app, ["gradient"])
+    result = runner.invoke(app, ["print", "Animated", "-a", "-d", "0"])
     assert result.exit_code == 0
-    assert "Gradient Showcase" in result.stdout
 
 
-def test_cli_rule_command():
-    """Rule command should print explanatory text alongside the gradient rule."""
+def test_rule_command_outputs_title() -> None:
+    """The ``rule`` command should include the provided title."""
 
-    result = runner.invoke(app, ["rule"])
+    result = runner.invoke(app, ["rule", "-t", "Section", "-c", "red,blue", "-T", "2"])
     assert result.exit_code == 0
-    assert "Gradient rules are perfect for separating sections." in result.stdout
+    assert "Section" in result.stdout
 
 
-def test_cli_panel_command():
-    """Panel command should wrap gradient text in a panel output."""
+def test_rule_command_invalid_colour() -> None:
+    """Invalid colours should cause the rule command to fail."""
 
-    result = runner.invoke(app, ["panel"])
+    result = runner.invoke(app, ["rule", "-c", "#GGGGGG"])
+    assert result.exit_code != 0
+
+
+def test_panel_command_renders_content(tmp_path: Path) -> None:
+    """The ``panel`` command should wrap file content in a gradient panel."""
+
+    file_path = tmp_path / "content.txt"
+    file_path.write_text("Panel body", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "panel",
+            str(file_path),
+            "-t",
+            "Info",
+            "--align",
+            "center",
+            "--padding",
+            "1,2",
+            "--no-expand",
+        ],
+    )
     assert result.exit_code == 0
-    assert "Panels can frame gradient text for call-outs and highlights." in result.stdout
+    assert "Panel body" in result.stdout
+    assert "Info" in result.stdout
 
 
-def test_cli_table_command():
-    """Table command should render gradient table content."""
+def test_panel_command_supports_animation() -> None:
+    """Animated panels should honour the duration flag."""
 
-    result = runner.invoke(app, ["table"])
+    result = runner.invoke(app, ["panel", "Animated panel", "-a", "-d", "0"])
     assert result.exit_code == 0
-    assert "Color stops" in result.stdout
 
 
-def test_cli_progress_command():
-    """Progress command should complete successfully with summary text."""
+def test_panel_command_rejects_bad_padding() -> None:
+    """Invalid padding strings should surface an error."""
 
-    result = runner.invoke(app, ["progress"])
-    assert result.exit_code == 0
-    assert "Gradient progress complete!" in result.stdout
-
-
-def test_cli_syntax_command():
-    """Syntax command should include its gradient heading."""
-
-    result = runner.invoke(app, ["syntax"])
-    assert result.exit_code == 0
-    assert "Gradient Syntax" in result.stdout
+    result = runner.invoke(app, ["panel", "Pad me", "-p", "1,2,3"])
+    assert result.exit_code != 0
 
 
-def test_cli_markdown_command():
-    """Markdown command should emit the markdown heading text."""
+def test_panel_command_rejects_bad_colour() -> None:
+    """Invalid colours should cause the panel command to fail."""
 
-    result = runner.invoke(app, ["markdown"])
-    assert result.exit_code == 0
-    assert "Gradient Markdown" in result.stdout
-
-
-def test_cli_markup_command():
-    """Markup command should parse markup and print the resulting text."""
-
-    result = runner.invoke(app, ["markup"])
-    assert result.exit_code == 0
-    assert "Rich markup meets gradients!" in result.stdout
-
-
-def test_cli_box_command():
-    """Box command should render descriptive gradient text."""
-
-    result = runner.invoke(app, ["box"])
-    assert result.exit_code == 0
-    assert "borders pair nicely with gradients" in result.stdout
-
-
-def test_cli_prompts_command():
-    """Prompts command should simulate a prompt and echo the response."""
-
-    result = runner.invoke(app, ["prompts"])
-    assert result.exit_code == 0
-    assert "Aurora Borealis" in result.stdout
-
-
-def test_cli_live_command():
-    """Live command should finish and print its closing message."""
-
-    result = runner.invoke(app, ["live"])
-    assert result.exit_code == 0
-    assert "Exited live rendering session." in result.stdout
+    result = runner.invoke(app, ["panel", "Oops", "-c", "#XYZ"])
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- replace the CLI with compact Typer commands for `print`, `rule`, and `panel` that match the documented behaviour
- add focused CLI integration tests covering text input modes, animations, and error handling

## Testing
- uv run --group dev pytest
- uv run --with ruff ruff check

------
https://chatgpt.com/codex/tasks/task_e_68ffffa79fa08327bc13beb48c86987a

## Summary by Sourcery

Rewrite the Typer-based CLI to match the documented commands by consolidating commands into print, rule, and panel, streamlining options, centralizing parsing logic, adding animation flags, and updating documentation and integration tests accordingly.

New Features:
- Provide a compact CLI with three core commands: print, rule, and panel matching the documented usage
- Add animation support via --animated and --duration flags in the core commands

Enhancements:
- Centralize helper functions for text sourcing, color stop parsing, padding, and error handling
- Streamline option definitions and remove legacy/demo commands to reduce CLI complexity
- Simplify version callback and global options handling

Documentation:
- Update docs/cli.md with detailed usage and options for the print, rule, and panel commands

Tests:
- Refactor CLI integration tests to focus on print, rule, and panel commands and remove obsolete unit tests