### PR TITLE
feat: implement Typer CLI with gradient help panels

### DIFF
--- a/src/rich_gradient/cli.py
+++ b/src/rich_gradient/cli.py
@@ -1,48 +1,139 @@
 """Typer-based command line interface for ``rich-gradient``.
 
-This module exposes three subcommands—``print``, ``rule``, and ``panel``—that
-mirror the usage documented in ``docs/cli.md``.  Each command accepts the same
-colour handling options (explicit stops, rainbow gradients, hue selection) and
-implements the ergonomic text sourcing described in the guide: inline text
-arguments, ``text=...`` syntax, or streamed standard input via ``-``.
+This CLI mirrors the functionality exposed by the underlying ``rich-gradient``
+renderables (text, panels, rules, and markdown) and provides a high-fidelity
+front end similar to the ``rich`` project's ``rich`` command.  In addition to
+exposing gradient-aware subcommands, the CLI renders contextual help inside
+``rich_gradient.panel.Panel`` instances so that ``--help`` output showcases the
+package's styling capabilities.
 
-The CLI is intentionally compact so that the options showcased in the
-documentation remain the single source of truth for expected behaviour.  Helper
-functions centralise repeated tasks such as parsing colour stops, padding
-strings, and resolving text sources.
+Every command honours the palette-handling options common across the project:
+explicit colour stops, rainbow gradients, background colours, hue selection,
+and optional animation with controllable duration.  Input text can be provided
+inline, loaded from files, or streamed from standard input when ``-`` is
+specified as the argument.
 """
 
-# pylint: disable=W0611
 from __future__ import annotations
 
 import sys
 import time
 from pathlib import Path
-from typing import Literal, Optional, Sequence, Tuple
+from typing import Literal, Optional, Sequence
 
 import typer
 from rich.align import Align
+from rich.box import ASCII, DOUBLE, HEAVY, ROUNDED, SQUARE, Box
 from rich.color import ColorParseError
 from rich.console import Console, RenderableType
+from rich.markdown import Markdown as RichMarkdown
 from rich.text import Text as RichText
+
+from click.core import ParameterSource
 
 from rich_gradient import __version__
 from rich_gradient.animated_gradient import AnimatedGradient
 from rich_gradient.animated_panel import AnimatedPanel
 from rich_gradient.animated_rule import AnimatedRule
+from rich_gradient.gradient import Gradient
 from rich_gradient.panel import Panel as GradientPanel
 from rich_gradient.rule import Rule as GradientRule
 from rich_gradient.text import Text as GradientText
 
 JustifyOption = Literal["left", "center", "right"]
+VerticalJustifyOption = Literal["top", "middle", "bottom"]
+OverflowOption = Literal["crop", "fold", "ellipsis"]
+RuleThickness = Literal[0, 1, 2, 3]
+BoxChoice = Literal["SQUARE", "ROUNDED", "HEAVY", "DOUBLE", "ASCII"]
 
-app = typer.Typer(help="Render colourful text, rules, and panels using gradients.")
+HELP_COLORS = ["#b877ff", "#ff6b9e", "#ffd56b"]
 
 
 def _create_console() -> Console:
-    """Return a console used for rendering CLI output."""
+    """Return a console configured for terminal output."""
 
-    return Console()
+    return Console(color_system="auto")
+
+
+class _GradientHelpMixin:
+    """Mixin that renders Click/Typer help inside a gradient panel."""
+
+    help_panel_colors: Sequence[str] = HELP_COLORS
+
+    def _render_help_panel(self, ctx: typer.Context, help_text: str) -> str:
+        """Return help text wrapped in a ``GradientPanel``.
+
+        Args:
+            ctx: The Typer context requesting help output.
+            help_text: The standard Click help string.
+        Returns:
+            A string representation of the help content rendered through a
+            gradient panel.
+        """
+
+        width = ctx.terminal_width or 100
+        constrained_width = max(60, min(width, 120))
+        console = Console(
+            record=True,
+            width=constrained_width,
+            color_system="truecolor",
+        )
+        title = ctx.command_path or "rich-gradient"
+        content = RichText(help_text.rstrip("\n"), no_wrap=False, overflow="fold")
+        panel = GradientPanel(
+            content,
+            colors=list(self.help_panel_colors),
+            rainbow=False,
+            hues=max(len(self.help_panel_colors), 2),
+            title=title,
+            title_align="left",
+            title_style="bold",  # Highlight the command path
+            padding=(1, 2),
+            expand=True,
+            justify="left",
+        )
+        panel.console = console
+        console.print(panel)
+        return console.export_text(clear=False)
+
+
+class GradientCommand(_GradientHelpMixin, typer.core.TyperCommand):
+    """Command subclass that emits help using gradient panels."""
+
+    def get_help(self, ctx: typer.Context) -> str:  # type: ignore[override]
+        """Render Click help text within a gradient panel."""
+
+        help_text = super().get_help(ctx)
+        return self._render_help_panel(ctx, help_text)
+
+
+class GradientGroup(_GradientHelpMixin, typer.core.TyperGroup):
+    """Group subclass that emits help using gradient panels."""
+
+    def get_help(self, ctx: typer.Context) -> str:  # type: ignore[override]
+        """Render Click help text within a gradient panel."""
+
+        help_text = super().get_help(ctx)
+        return self._render_help_panel(ctx, help_text)
+
+
+BOX_MAP: dict[BoxChoice, Box] = {
+    "SQUARE": SQUARE,
+    "ROUNDED": ROUNDED,
+    "HEAVY": HEAVY,
+    "DOUBLE": DOUBLE,
+    "ASCII": ASCII,
+}
+
+DEFAULT_SOURCES = {ParameterSource.DEFAULT, ParameterSource.DEFAULT_MAP}
+
+app = typer.Typer(
+    cls=GradientGroup,
+    add_completion=False,
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 
 
 def _version_callback(value: bool) -> None:
@@ -54,17 +145,21 @@ def _version_callback(value: bool) -> None:
 
 
 @app.callback()
-def main(
-    version: bool = typer.Option(  # noqa: D401 - Typer uses the callback docstring.
+def root_callback(
+    ctx: typer.Context,
+    version: bool = typer.Option(
         False,
         "--version",
         "-V",
-        help="Show the rich-gradient version and exit.",
         callback=_version_callback,
         is_eager=True,
-    )
+        help="Show the rich-gradient version and exit.",
+    ),
 ) -> None:
-    """Root callback for shared global options."""
+    """Root callback registering shared global options."""
+
+    # ``ctx`` is required so Typer retains the context for subcommands.
+    _ = ctx
 
 
 def _read_text_source(argument: Optional[str]) -> str:
@@ -97,7 +192,7 @@ def _read_text_source(argument: Optional[str]) -> str:
     return argument
 
 
-def _parse_color_stops(spec: Optional[str]) -> Optional[Sequence[str]]:
+def _parse_color_stops(spec: Optional[str]) -> Optional[list[str]]:
     """Split a comma-separated colour specification into individual stops."""
 
     if spec is None:
@@ -108,7 +203,7 @@ def _parse_color_stops(spec: Optional[str]) -> Optional[Sequence[str]]:
     return stops
 
 
-def _parse_padding(value: Optional[str]) -> Tuple[int, int, int, int]:
+def _parse_padding(value: Optional[str]) -> tuple[int, int, int, int]:
     """Parse padding strings (``"1"``, ``"2,4"``, ``"1,2,3,4"``) into a 4-tuple."""
 
     if not value:
@@ -116,7 +211,7 @@ def _parse_padding(value: Optional[str]) -> Tuple[int, int, int, int]:
     parts = [element.strip() for element in value.split(",") if element.strip()]
     try:
         numbers = [int(part) for part in parts]
-    except ValueError as error:  # pragma: no cover - validated via typer
+    except ValueError as error:  # pragma: no cover - validated via Typer
         raise typer.BadParameter("padding must contain integers") from error
 
     if len(numbers) == 1:
@@ -131,10 +226,10 @@ def _parse_padding(value: Optional[str]) -> Tuple[int, int, int, int]:
     return (top, right, bottom, left)
 
 
-def _as_list(values: Optional[Sequence[str]]) -> Optional[list[str]]:
-    """Convert an optional sequence of strings into a mutable list."""
+def _parse_box_choice(choice: BoxChoice) -> Box:
+    """Return the ``rich.box`` instance matching the requested style."""
 
-    return list(values) if values is not None else None
+    return BOX_MAP[choice]
 
 
 def _run_animation(animation: AnimatedGradient, duration: float) -> None:
@@ -148,7 +243,7 @@ def _run_animation(animation: AnimatedGradient, duration: float) -> None:
     try:
         with animation:
             time.sleep(duration)
-    except KeyboardInterrupt:
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
         animation.stop()
 
 
@@ -158,8 +253,8 @@ def _handle_color_error(error: ColorParseError | ValueError) -> None:
     raise typer.BadParameter(str(error)) from error
 
 
-@app.command("print")
-def print_command(  # noqa: D401 - Command help is provided via Typer metadata.
+@app.command("print", cls=GradientCommand)
+def print_command(
     text: Optional[str] = typer.Argument(
         None,
         help="Text to render, '-' for stdin, or text=...",
@@ -168,53 +263,99 @@ def print_command(  # noqa: D401 - Command help is provided via Typer metadata.
         None,
         "--colors",
         "-c",
-        help="Comma-separated colour stops (e.g. '#f00,#ff0,#0f0').",
+        metavar="COLORS",
+        help="Comma-separated colour stops (e.g., 'red,#ff9900,yellow').",
     ),
     rainbow: bool = typer.Option(
         False,
-        "--rainbow/--no-rainbow",
-        "-R/-n",
-        help="Generate a rainbow gradient automatically.",
+        "--rainbow",
+        "-r",
+        help="Print text in rainbow colours (overrides --colors).",
     ),
     hues: int = typer.Option(
         7,
         "--hues",
         "-h",
         min=2,
-        help="Number of hues when auto-generating colours.",
+        metavar="HUES",
+        help="The number of hues to use for a random gradient.",
+    ),
+    style: Optional[str] = typer.Option(
+        None,
+        "--style",
+        metavar="STYLE",
+        help="Rich style string applied to the text.",
     ),
     justify: JustifyOption = typer.Option(
         "left",
         "--justify",
         "-j",
         case_sensitive=False,
-        help="Align the rendered text.",
+        metavar="JUSTIFY",
+        help="Justification of the text.",
     ),
-    animated: bool = typer.Option(
+    overflow: OverflowOption = typer.Option(
+        "fold",
+        "--overflow",
+        metavar="OVERFLOW",
+        help="How to handle text overflow.",
+    ),
+    no_wrap: bool = typer.Option(
         False,
-        "--animated",
-        "-a",
-        help="Animate the gradient instead of rendering once.",
+        "--no-wrap",
+        help="Disable text wrapping.",
+    ),
+    end: str = typer.Option(
+        "\n",
+        "--end",
+        metavar="END",
+        help="String appended after the text is printed.",
+    ),
+    bgcolors: Optional[str] = typer.Option(
+        None,
+        "--bgcolors",
+        metavar="BGCOLORS",
+        help=(
+            "Comma-separated list of background colours for the gradient "
+            "(e.g., 'red,#ff9900,yellow')."
+        ),
+    ),
+    animate: bool = typer.Option(
+        False,
+        "--animate",
+        help="Animate the gradient text.",
     ),
     duration: float = typer.Option(
         5.0,
         "--duration",
         "-d",
         min=0.0,
-        help="Animation length in seconds.",
+        metavar="DURATION",
+        help="Duration of the animation in seconds.",
     ),
 ) -> None:
-    """Render gradient text or an animated gradient in place."""
+    """Print gradient-coloured text to the console."""
 
     console = _create_console()
     text_value = _read_text_source(text)
-    color_stops = _as_list(_parse_color_stops(colors))
+    color_stops = _parse_color_stops(colors)
+    bg_color_stops = _parse_color_stops(bgcolors)
+
+    base_text = RichText.from_markup(
+        text_value,
+        style=style or "",
+        justify=justify,
+        overflow=overflow,
+    )
+    base_text.no_wrap = no_wrap
+    base_text.end = end
 
     try:
-        if animated:
+        if animate:
             animation = AnimatedGradient(
-                renderables=text_value,
+                renderables=base_text,
                 colors=color_stops,
+                bg_colors=bg_color_stops,
                 rainbow=rainbow,
                 hues=hues,
                 console=console,
@@ -228,227 +369,500 @@ def print_command(  # noqa: D401 - Command help is provided via Typer metadata.
                 colors=color_stops,
                 rainbow=rainbow,
                 hues=hues,
+                style=style or "",
                 justify=justify,
+                overflow=overflow,
+                no_wrap=no_wrap,
+                end=end,
+                bgcolors=bg_color_stops,
             )
             console.print(gradient_text)
-    except ColorParseError as error:
+    except (ColorParseError, ValueError) as error:
         _handle_color_error(error)
 
 
-@app.command("rule")
-def rule_command(  # noqa: D401 - Command help is provided via Typer metadata.
-    title: Optional[str] = typer.Option(
+@app.command("panel", cls=GradientCommand)
+def panel_command(
+    ctx: typer.Context,
+    renderable: Optional[str] = typer.Argument(
         None,
-        "--title",
-        "-t",
-        help="Optional title displayed within the rule.",
-    ),
-    title_style: str = typer.Option(
-        "bold",
-        "--title-style",
-        "-s",
-        help="Rich style applied to the rule title.",
-    ),
-    justify: JustifyOption = typer.Option(
-        "center",
-        "--justify",
-        "-j",
-        case_sensitive=False,
-        help="Alignment for the rule title.",
+        help="Panel content, '-' for stdin, or text=...",
     ),
     colors: Optional[str] = typer.Option(
         None,
         "--colors",
         "-c",
-        help="Comma-separated colour stops for the rule.",
+        metavar="COLORS",
+        help="Comma-separated list of colours for the gradient.",
+    ),
+    bgcolors: Optional[str] = typer.Option(
+        None,
+        "--bgcolors",
+        metavar="BGCOLORS",
+        help=(
+            "Comma-separated list of background colours for the gradient "
+            "(e.g., 'red,#ff9900,yellow')."
+        ),
     ),
     rainbow: bool = typer.Option(
         False,
-        "--rainbow/--no-rainbow",
-        "-R/-n",
-        help="Generate a rainbow gradient across the rule.",
+        "--rainbow",
+        "-r",
+        help="Use rainbow colours for the gradient.",
     ),
     hues: int = typer.Option(
-        7,
+        5,
         "--hues",
-        "-h",
+        metavar="HUES",
         min=2,
-        help="Number of hues when auto-generating colours.",
+        help="Number of hues for rainbow gradient.",
     ),
-    thickness: int = typer.Option(
-        1,
-        "--thickness",
-        "-T",
-        min=0,
-        max=3,
-        help="Line thickness between 0 and 3.",
+    title: Optional[str] = typer.Option(
+        None,
+        "--title",
+        "-t",
+        metavar="TITLE",
+        help="Title of the panel.",
     ),
-    animated: bool = typer.Option(
+    title_style: Optional[str] = typer.Option(
+        None,
+        "--title-style",
+        metavar="TITLE_STYLE",
+        show_default="bold",
+        help="Style applied to the panel title (requires --title).",
+    ),
+    title_align: JustifyOption = typer.Option(
+        "center",
+        "--title-align",
+        metavar="TITLE_ALIGN",
+        case_sensitive=False,
+        help="Alignment of the panel title (requires --title).",
+    ),
+    subtitle: Optional[str] = typer.Option(
+        None,
+        "--subtitle",
+        metavar="SUBTITLE",
+        help="Subtitle of the panel.",
+    ),
+    subtitle_style: Optional[str] = typer.Option(
+        None,
+        "--subtitle-style",
+        metavar="SUBTITLE_STYLE",
+        help="Style applied to the panel subtitle (requires --subtitle).",
+    ),
+    subtitle_align: JustifyOption = typer.Option(
+        "right",
+        "--subtitle-align",
+        metavar="SUBTITLE_ALIGN",
+        case_sensitive=False,
+        help="Alignment of the panel subtitle (requires --subtitle).",
+    ),
+    style: Optional[str] = typer.Option(
+        None,
+        "--style",
+        metavar="STYLE",
+        help="Style applied to the panel content.",
+    ),
+    border_style: Optional[str] = typer.Option(
+        None,
+        "--border-style",
+        metavar="BORDER_STYLE",
+        help="Style applied to the panel border.",
+    ),
+    padding: Optional[str] = typer.Option(
+        None,
+        "--padding",
+        "-p",
+        metavar="PADDING",
+        help="Padding inside the panel (1, 2, or 4 comma-separated integers).",
+    ),
+    vertical_justify: VerticalJustifyOption = typer.Option(
+        "top",
+        "--vertical-justify",
+        "-V",
+        metavar="VERTICAL_JUSTIFY",
+        case_sensitive=False,
+        help="Vertical justification of the panel content.",
+    ),
+    text_justify: JustifyOption = typer.Option(
+        "left",
+        "--text-justify",
+        "-J",
+        metavar="TEXT_JUSTIFY",
+        case_sensitive=False,
+        help="Justification of the text inside the panel.",
+    ),
+    justify: JustifyOption = typer.Option(
+        "left",
+        "--justify",
+        "-j",
+        metavar="JUSTIFY",
+        case_sensitive=False,
+        help="Justification of the panel itself.",
+    ),
+    expand: bool = typer.Option(
+        True,
+        "--expand/--no-expand",
+        "-e/-E",
+        help="Expand the panel to fill the width of the console.",
+    ),
+    width: Optional[int] = typer.Option(
+        None,
+        "--width",
+        metavar="WIDTH",
+        help="Width of the panel (requires --no-expand).",
+    ),
+    height: Optional[int] = typer.Option(
+        None,
+        "--height",
+        metavar="HEIGHT",
+        help="Height of the panel.",
+    ),
+    end: str = typer.Option(
+        "\n",
+        "--end",
+        metavar="END",
+        help="String appended after the panel is printed.",
+    ),
+    box: BoxChoice = typer.Option(
+        "ROUNDED",
+        "--box",
+        metavar="BOX",
+        help="Box style for the panel border.",
+    ),
+    animate: bool = typer.Option(
         False,
-        "--animated",
-        "-a",
-        help="Animate the rule using Rich Live.",
+        "--animate",
+        help="Animate the panel gradient.",
     ),
     duration: float = typer.Option(
         5.0,
         "--duration",
         "-d",
         min=0.0,
-        help="Animation length in seconds.",
+        metavar="DURATION",
+        help="Duration of the panel animation in seconds.",
     ),
 ) -> None:
-    """Draw a gradient rule line, optionally with animation."""
+    """Display text inside a gradient panel."""
 
     console = _create_console()
-    color_stops = _as_list(_parse_color_stops(colors))
+    text_value = _read_text_source(renderable)
+    color_stops = _parse_color_stops(colors)
+    bg_color_stops = _parse_color_stops(bgcolors)
+    padding_values = _parse_padding(padding)
+
+    if width is not None and expand:
+        raise typer.BadParameter("--width requires --no-expand")
+
+    title_style_source = ctx.get_parameter_source("title_style")
+    title_align_source = ctx.get_parameter_source("title_align")
+    subtitle_style_source = ctx.get_parameter_source("subtitle_style")
+    subtitle_align_source = ctx.get_parameter_source("subtitle_align")
+
+    if title is None and title_style_source not in DEFAULT_SOURCES and title_style:
+        raise typer.BadParameter("--title-style requires --title to be set")
+    if title is None and title_align_source not in DEFAULT_SOURCES:
+        raise typer.BadParameter("--title-align requires --title to be set")
+    if subtitle is None and subtitle_style_source not in DEFAULT_SOURCES and subtitle_style:
+        raise typer.BadParameter("--subtitle-style requires --subtitle to be set")
+    if subtitle is None and subtitle_align_source not in DEFAULT_SOURCES:
+        raise typer.BadParameter("--subtitle-align requires --subtitle to be set")
+
+    resolved_title_style = title_style or ("bold" if title else "")
+    resolved_subtitle_style = subtitle_style or ""
+
+    content = Align(
+        RichText.from_markup(text_value, style=style or ""),
+        align=text_justify,
+    )
 
     try:
-        if animated:
+        panel_kwargs = dict(
+            colors=color_stops,
+            bg_colors=bg_color_stops,
+            rainbow=rainbow,
+            hues=hues,
+            title=title,
+            title_style=resolved_title_style,
+            title_align=title_align,
+            subtitle=subtitle,
+            subtitle_style=resolved_subtitle_style,
+            subtitle_align=subtitle_align,
+            border_style=border_style or "",
+            padding=padding_values,
+            expand=expand,
+            justify=justify,
+            vertical_justify=vertical_justify,
+            box=_parse_box_choice(box),
+            style=style or "",
+            width=width,
+            height=height,
+        )
+        if animate:
+            animation = AnimatedPanel(
+                content,
+                console=console,
+                **panel_kwargs,
+            )
+            _run_animation(animation, duration)
+        else:
+            panel_renderable = GradientPanel(
+                content,
+                **panel_kwargs,
+            )
+            panel_renderable.console = console
+            console.print(panel_renderable, end=end)
+    except (ColorParseError, ValueError) as error:
+        _handle_color_error(error)
+
+
+@app.command("rule", cls=GradientCommand)
+def rule_command(
+    title: Optional[str] = typer.Option(
+        None,
+        "--title",
+        "-t",
+        metavar="TITLE",
+        help="Title of the rule.",
+    ),
+    title_style: Optional[str] = typer.Option(
+        None,
+        "--title-style",
+        "-s",
+        metavar="TITLE_STYLE",
+        help="Style applied to the rule title.",
+    ),
+    colors: Optional[str] = typer.Option(
+        None,
+        "--colors",
+        "-c",
+        metavar="COLORS",
+        help="Comma-separated list of colours for the gradient.",
+    ),
+    bgcolors: Optional[str] = typer.Option(
+        None,
+        "--bgcolors",
+        metavar="BGCOLORS",
+        help="Comma-separated list of background colours for the gradient.",
+    ),
+    rainbow: bool = typer.Option(
+        False,
+        "--rainbow",
+        "-r",
+        help="Use rainbow colours for the gradient.",
+    ),
+    hues: int = typer.Option(
+        10,
+        "--hues",
+        metavar="HUES",
+        min=2,
+        help="Number of hues for rainbow gradient.",
+    ),
+    end: str = typer.Option(
+        "\n",
+        "--end",
+        metavar="END",
+        help="String appended after the rule is printed.",
+    ),
+    thickness: RuleThickness = typer.Option(
+        2,
+        "--thickness",
+        "-T",
+        metavar="THICKNESS",
+        help="Thickness of the rule line.",
+    ),
+    align: JustifyOption = typer.Option(
+        "center",
+        "--align",
+        "-a",
+        metavar="ALIGN",
+        case_sensitive=False,
+        help="Alignment of the rule in the console.",
+    ),
+    animate: bool = typer.Option(
+        False,
+        "--animate",
+        help="Animate the rule gradient.",
+    ),
+    duration: float = typer.Option(
+        5.0,
+        "--duration",
+        "-d",
+        min=0.0,
+        metavar="DURATION",
+        help="Duration of the rule animation in seconds.",
+    ),
+) -> None:
+    """Display a gradient rule in the console."""
+
+    console = _create_console()
+    color_stops = _parse_color_stops(colors)
+    bg_color_stops = _parse_color_stops(bgcolors)
+
+    try:
+        if animate:
             animation = AnimatedRule(
                 title=title,
-                title_style=title_style,
+                title_style=title_style or "bold",
                 colors=color_stops,
+                bg_colors=bg_color_stops,
                 rainbow=rainbow,
                 hues=hues,
                 thickness=thickness,
-                align=justify,
+                align=align,
                 console=console,
+                end=end,
             )
             _run_animation(animation, duration)
         else:
             rule_renderable = GradientRule(
                 title=title,
-                title_style=title_style,
+                title_style=title_style or "bold",
                 colors=color_stops,
+                bg_colors=bg_color_stops,
                 rainbow=rainbow,
                 hues=hues,
                 thickness=thickness,
-                align=justify,
+                align=align,
                 console=console,
+                end=end,
             )
             console.print(rule_renderable)
     except (ColorParseError, ValueError) as error:
         _handle_color_error(error)
 
 
-def _panel_content(text: str, align: JustifyOption) -> RenderableType:
-    """Return an aligned renderable for panel content."""
-
-    return Align(RichText.from_markup(text), align=align)
-
-
-@app.command("panel")
-def panel_command(  # noqa: D401 - Command help is provided via Typer metadata.
-    text: Optional[str] = typer.Argument(
+@app.command("markdown", cls=GradientCommand)
+def markdown_command(
+    markdown: Optional[str] = typer.Argument(
         None,
-        help="Panel content, '-' for stdin, or text=...",
-    ),
-    title: Optional[str] = typer.Option(
-        None,
-        "--title",
-        "-t",
-        help="Optional panel title.",
-    ),
-    title_style: str = typer.Option(
-        "bold",
-        "--title-style",
-        "-s",
-        help="Rich style applied to the panel title.",
-    ),
-    justify: JustifyOption = typer.Option(
-        "center",
-        "--justify",
-        "-j",
-        case_sensitive=False,
-        help="Title alignment inside the panel.",
-    ),
-    align: JustifyOption = typer.Option(
-        "left",
-        "--align",
-        case_sensitive=False,
-        help="Content alignment inside the panel.",
+        metavar="MARKDOWN",
+        help="Markdown text, file path, or '-' for stdin.",
     ),
     colors: Optional[str] = typer.Option(
         None,
         "--colors",
         "-c",
-        help="Comma-separated colour stops for the panel background.",
+        metavar="COLORS",
+        help="Comma-separated list of colours for the gradient.",
+    ),
+    bgcolors: Optional[str] = typer.Option(
+        None,
+        "--bgcolors",
+        metavar="BGCOLORS",
+        help="Comma-separated list of background colours for the gradient.",
     ),
     rainbow: bool = typer.Option(
         False,
-        "--rainbow/--no-rainbow",
-        "-R/-n",
-        help="Generate a rainbow panel background.",
+        "--rainbow",
+        "-r",
+        help="Use rainbow colours for the gradient (overrides --colors).",
     ),
     hues: int = typer.Option(
         7,
         "--hues",
-        "-h",
+        metavar="HUES",
         min=2,
-        help="Number of hues when auto-generating colours.",
+        help="The number of hues to use for a random gradient.",
     ),
-    padding: Optional[str] = typer.Option(
+    style: Optional[str] = typer.Option(
         None,
-        "--padding",
-        "-p",
-        help="Panel padding (N, V,H or T,R,B,L).",
+        "--style",
+        metavar="STYLE",
+        help="Base style applied to the markdown content.",
     ),
-    expand: bool = typer.Option(
-        True,
-        "--expand/--no-expand",
-        help="Expand the panel to available width.",
+    justify: JustifyOption = typer.Option(
+        "left",
+        "--justify",
+        "-j",
+        metavar="JUSTIFY",
+        case_sensitive=False,
+        help="Justification of the markdown output.",
     ),
-    animated: bool = typer.Option(
+    overflow: OverflowOption = typer.Option(
+        "fold",
+        "--overflow",
+        metavar="OVERFLOW",
+        help="How to handle overflow of markdown text.",
+    ),
+    no_wrap: bool = typer.Option(
         False,
-        "--animated",
-        "-a",
-        help="Animate the panel background.",
+        "--no-wrap",
+        help="Disable wrapping of markdown text.",
+    ),
+    end: str = typer.Option(
+        "\n",
+        "--end",
+        metavar="END",
+        help="String appended after the markdown text is printed.",
+    ),
+    animate: bool = typer.Option(
+        False,
+        "--animate",
+        help="Animate the gradient markdown text.",
     ),
     duration: float = typer.Option(
         5.0,
         "--duration",
         "-d",
         min=0.0,
-        help="Animation length in seconds.",
+        metavar="DURATION",
+        help="Duration of the animation in seconds.",
     ),
 ) -> None:
-    """Produce a gradient-backed panel around text or streamed content."""
+    """Render markdown text with gradient colours in the console."""
 
     console = _create_console()
-    text_value = _read_text_source(text)
-    color_stops = _as_list(_parse_color_stops(colors))
-    padding_values = _parse_padding(padding)
-    content = _panel_content(text_value, align)
+    markdown_value = _read_text_source(markdown)
+    color_stops = _parse_color_stops(colors)
+    bg_color_stops = _parse_color_stops(bgcolors)
+
+    rich_markdown = RichMarkdown(markdown_value, style=style or "")
+    aligned_renderable: RenderableType = Align(
+        rich_markdown,
+        align=justify,
+    )
 
     try:
-        if animated:
-            animation = AnimatedPanel(
-                content,
+        if animate:
+            animation = AnimatedGradient(
+                renderables=aligned_renderable,
                 colors=color_stops,
+                bg_colors=bg_color_stops,
                 rainbow=rainbow,
                 hues=hues,
-                title=title,
-                title_align=justify,
-                title_style=title_style,
-                padding=padding_values,
-                expand=expand,
                 console=console,
-                justify="center",
+                justify=justify,
+                expand=True,
             )
             _run_animation(animation, duration)
         else:
-            panel_renderable = GradientPanel(
-                content,
+            gradient_renderable = Gradient(
+                aligned_renderable,
                 colors=color_stops,
+                bg_colors=bg_color_stops,
+                console=console,
                 rainbow=rainbow,
                 hues=hues,
-                title=title,
-                title_align=justify,
-                title_style=title_style,
-                padding=padding_values,
-                expand=expand,
-                justify="center",
+                justify=justify,
+                expand=True,
             )
-            console.print(panel_renderable)
-    except ColorParseError as error:
+            console.print(
+                gradient_renderable,
+                end=end,
+                overflow=overflow,
+                no_wrap=True if no_wrap else None,
+            )
+    except (ColorParseError, ValueError) as error:
         _handle_color_error(error)
+
+
+def main() -> None:
+    """Execute the Typer application."""
+
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Integration tests for the Typer-based ``rich-gradient`` CLI."""
+"""Integration tests for the ``rich-gradient`` Typer CLI."""
 
 from __future__ import annotations
 
@@ -17,14 +17,25 @@ def test_version_option() -> None:
 
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert result.stdout.strip()  # Version string is non-empty
+    assert result.stdout.strip()
+
+
+def test_help_renders_gradient_panel() -> None:
+    """Help output should render inside a gradient panel."""
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # Rounded box-drawing characters signal that a panel rendered.
+    assert "╭" in result.stdout
+    assert "rich-gradient" in result.stdout
+    assert "Commands" in result.stdout
 
 
 @pytest.mark.parametrize(
     "args, expected",
     [
         (["print", "Hello world"], "Hello world"),
-        (["print", "text=From assignment"], "From assignment"),
+        (["print", "text=Inline"], "Inline"),
     ],
 )
 def test_print_command_renders_text(args: list[str], expected: str) -> None:
@@ -43,33 +54,49 @@ def test_print_command_reads_stdin() -> None:
     assert "Streamed input" in result.stdout
 
 
-def test_print_command_handles_colours() -> None:
-    """Explicit colour stops should render without errors."""
+def test_print_command_handles_colour_options() -> None:
+    """Explicit colour stops and background colours should render without errors."""
 
-    result = runner.invoke(app, ["print", "Colourful", "-c", "#f00,#0f0"])
+    result = runner.invoke(
+        app,
+        [
+            "print",
+            "Colourful",
+            "-c",
+            "#f00,#0f0",
+            "--bgcolors",
+            "#111111,#222222",
+            "--style",
+            "bold",
+        ],
+    )
     assert result.exit_code == 0
     assert "Colourful" in result.stdout
 
 
 def test_print_command_rejects_invalid_colour() -> None:
-    """An invalid colour stop should produce an error message."""
+    """Invalid colour stops should produce an error message."""
 
     result = runner.invoke(app, ["print", "Bad", "-c", "not-a-colour"])
     assert result.exit_code != 0
-    assert "Error" in result.stdout
+    stderr = result.stderr or ""
+    assert "Invalid value for" in stderr or "Error" in stderr
 
 
 def test_print_command_supports_animation() -> None:
     """Animations with zero duration should complete immediately."""
 
-    result = runner.invoke(app, ["print", "Animated", "-a", "-d", "0"])
+    result = runner.invoke(app, ["print", "Animated", "--animate", "-d", "0"])
     assert result.exit_code == 0
 
 
 def test_rule_command_outputs_title() -> None:
     """The ``rule`` command should include the provided title."""
 
-    result = runner.invoke(app, ["rule", "-t", "Section", "-c", "red,blue", "-T", "2"])
+    result = runner.invoke(
+        app,
+        ["rule", "-t", "Section", "-c", "red,blue", "-T", "2", "--align", "left"],
+    )
     assert result.exit_code == 0
     assert "Section" in result.stdout
 
@@ -79,6 +106,8 @@ def test_rule_command_invalid_colour() -> None:
 
     result = runner.invoke(app, ["rule", "-c", "#GGGGGG"])
     assert result.exit_code != 0
+    stderr = result.stderr or ""
+    assert "Invalid value for" in stderr or "Error" in stderr
 
 
 def test_panel_command_renders_content(tmp_path: Path) -> None:
@@ -94,23 +123,37 @@ def test_panel_command_renders_content(tmp_path: Path) -> None:
             str(file_path),
             "-t",
             "Info",
-            "--align",
-            "center",
+            "--subtitle",
+            "Details",
             "--padding",
             "1,2",
+            "--text-justify",
+            "center",
             "--no-expand",
+            "--box",
+            "ASCII",
         ],
     )
     assert result.exit_code == 0
     assert "Panel body" in result.stdout
     assert "Info" in result.stdout
+    assert "Details" in result.stdout
 
 
-def test_panel_command_supports_animation() -> None:
-    """Animated panels should honour the duration flag."""
+def test_panel_command_requires_title_for_style() -> None:
+    """Providing ``--title-style`` without a title should raise an error."""
 
-    result = runner.invoke(app, ["panel", "Animated panel", "-a", "-d", "0"])
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["panel", "content", "--title-style", "italic"])
+    assert result.exit_code != 0
+    assert "requires --title" in (result.stderr or "")
+
+
+def test_panel_command_requires_no_expand_for_width() -> None:
+    """Specifying ``--width`` should demand ``--no-expand``."""
+
+    result = runner.invoke(app, ["panel", "content", "--width", "40"])
+    assert result.exit_code != 0
+    assert "requires --no-expand" in (result.stderr or "")
 
 
 def test_panel_command_rejects_bad_padding() -> None:
@@ -125,3 +168,49 @@ def test_panel_command_rejects_bad_colour() -> None:
 
     result = runner.invoke(app, ["panel", "Oops", "-c", "#XYZ"])
     assert result.exit_code != 0
+
+
+def test_panel_command_supports_animation() -> None:
+    """Animated panels should honour the duration flag."""
+
+    result = runner.invoke(app, ["panel", "Animated panel", "--animate", "-d", "0"])
+    assert result.exit_code == 0
+
+
+def test_markdown_command_renders_text(tmp_path: Path) -> None:
+    """Markdown content provided via file should render inside a gradient."""
+
+    markdown_file = tmp_path / "doc.md"
+    markdown_file.write_text("# Heading\n\nBody", encoding="utf-8")
+
+    result = runner.invoke(app, ["markdown", str(markdown_file), "--justify", "center"])
+    assert result.exit_code == 0
+    assert "Heading" in result.stdout
+    assert "Body" in result.stdout
+
+
+def test_markdown_command_accepts_inline_text() -> None:
+    """Inline markdown text should render without errors."""
+
+    result = runner.invoke(
+        app,
+        ["markdown", "# Title", "--colors", "magenta,cyan", "--bgcolors", "black"],
+    )
+    assert result.exit_code == 0
+    assert "Title" in result.stdout
+
+
+def test_markdown_command_invalid_colour() -> None:
+    """Invalid colour specifications should surface an error."""
+
+    result = runner.invoke(app, ["markdown", "# Bad", "--colors", "not-a-colour"])
+    assert result.exit_code != 0
+    stderr = result.stderr or ""
+    assert "Invalid value for" in stderr or "Error" in stderr
+
+
+def test_markdown_command_animation() -> None:
+    """Animated markdown rendering should respect the duration flag."""
+
+    result = runner.invoke(app, ["markdown", "# Animated", "--animate", "-d", "0"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- replace the CLI entry point with a Typer app that renders help inside gradient panels and exposes print, panel, rule, and markdown commands
- add shared parsing, validation, and animation helpers to support the new option set including colours, background colours, styles, and alignment controls
- expand the CLI integration suite to cover help output, option validation, new arguments, and markdown rendering

## Testing
- python -m ruff check .
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_6905ed6c54688327a95a3c6dbaffc98b

## Summary by Sourcery

Implement a new Typer-based CLI that replaces the old entry point and provides gradient-aware `print`, `panel`, `rule`, and `markdown` commands with rich styling, background colours, animation support, and enhanced help panels, backed by shared parsing/validation helpers and an expanded test suite.

New Features:
- Replace the CLI entry point with a Typer application exposing `print`, `panel`, `rule`, and `markdown` subcommands
- Render contextual help inside gradient panels for all commands
- Add a `markdown` command to render markdown content with gradient colours
- Support animation of text, panels, rules, and markdown with configurable durations

Enhancements:
- Introduce shared parsing and validation helpers for colour stops, padding, and box styles
- Implement custom TyperCommand and TyperGroup subclasses (`GradientCommand`, `GradientGroup`) to emit gradient-styled help
- Extend command options to include background colours, rich styles, alignment, overflow, wrapping, width/height, box styles, and end strings

Tests:
- Expand CLI integration tests to cover help output, option validation, error cases, panel and markdown rendering, and animation flags